### PR TITLE
Remove globals and init() side-effects from blockchain package

### DIFF
--- a/blockchain/interceptors.go
+++ b/blockchain/interceptors.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func jobValidationInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,
+func (p Processor) jobValidationInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler) error {
 
 	md, ok := metadata.FromIncomingContext(ss.Context())
@@ -30,10 +30,10 @@ func jobValidationInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.
 
 	jobSignatureBytes := common.FromHex(jobSignatureMd[0])
 
-	if IsValidJobInvocation(jobAddressBytes, jobSignatureBytes) {
+	if p.IsValidJobInvocation(jobAddressBytes, jobSignatureBytes) {
 		err := handler(srv, ss)
 		if err == nil {
-			CompleteJob(jobAddressBytes, jobSignatureBytes)
+			p.CompleteJob(jobAddressBytes, jobSignatureBytes)
 		}
 		return err
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/singnet/snet-daemon/blockchain"
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -56,6 +57,6 @@ func GetGrpcHandler() grpc.StreamHandler {
 	return grpcLoopback
 }
 
-func GetHttpHandler() http.HandlerFunc {
-	return httpToHttp
+func GetHttpHandler(bp blockchain.Processor) http.Handler {
+	return httpToHttp(bp)
 }

--- a/resources/test/main_test.go
+++ b/resources/test/main_test.go
@@ -62,10 +62,10 @@ func TestEndToEnd(t *testing.T) {
 	runCommand("", nil, "rm", "-rf", dbPath).Wait()
 	runCommand("", nil, "rm", "-rf", buildPath).Wait()
 
-	runCommand("", nil, "go", "build", "-o",
+	require.NoError(t, runCommand("", nil, "go", "build", "-o",
 		filepath.Join(buildPath, "snetd"),
 		filepath.Join(cwd, "..", "..", "snetd", "snetd.go"),
-	).Wait()
+	).Wait(), "Unable to build snetd")
 
 	runCommand(blockchainPath, nil, "npm", "run", "create-mnemonic").Wait()
 	rawMnemonic, err := ioutil.ReadFile(buildStatePath + "/Mnemonic.json")

--- a/snetd/snetd.go
+++ b/snetd/snetd.go
@@ -29,6 +29,10 @@ func main() {
 		log.WithError(err).Panic("error listening")
 	}
 
+	blockProc := blockchain.NewProcessor()
+	blockProc.StartLoop()
+	// TODO(aiden) defer StopLoop
+
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
 		mux := cmux.New(lis)
 		grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldPrefixSendSettings("content-type",
@@ -36,7 +40,7 @@ func main() {
 		httpL := mux.Match(cmux.HTTP1Fast())
 
 		grpcServer := grpc.NewServer(grpc.UnknownServiceHandler(handler.GetGrpcHandler()),
-			grpc.StreamInterceptor(blockchain.GetGrpcStreamInterceptor()))
+			grpc.StreamInterceptor(blockProc.GrpcStreamInterceptor()))
 		grpcWebServer := grpcweb.WrapServer(grpcServer)
 
 		log.Debug("starting daemon")
@@ -59,7 +63,7 @@ func main() {
 	} else {
 		log.Debug("starting daemon")
 
-		go http.Serve(lis, handler.GetHttpHandler())
+		go http.Serve(lis, handler.GetHttpHandler(blockProc))
 	}
 
 	defer db.Shutdown()


### PR DESCRIPTION
A first pass at showing how we can avoid shared global state and
implicit cross-package dependencies by threading things through. This
should greatly improve testability and maintainability in the long term.