### PR TITLE
Add basic command-line daemon flags

### DIFF
--- a/blockchain/tasks.go
+++ b/blockchain/tasks.go
@@ -58,7 +58,7 @@ func (p Processor) processJobCompletions() {
 }
 
 func (p Processor) processEvents() {
-	sleepSecs := config.GetDuration(config.PollSleepSecsKey)
+	sleepSecs := config.GetDuration(config.PollSleepKey)
 	agentContractAddress := config.GetString(config.AgentContractAddressKey)
 
 	a, err := abi.JSON(strings.NewReader(AgentABI))
@@ -73,7 +73,7 @@ func (p Processor) processEvents() {
 	jobCompletedId := a.Events["JobCompleted"].Id()
 
 	for {
-		time.Sleep(time.Second * sleepSecs)
+		time.Sleep(sleepSecs)
 
 		// We have to do a raw call because the standard method of ethClient.HeaderByNumber(ctx, nil) errors on
 		// unmarshaling the response currently. See https://github.com/ethereum/go-ethereum/issues/3230

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -36,26 +35,19 @@ func init() {
 	vip.SetEnvPrefix("SNET")
 	vip.AutomaticEnv()
 
-	vip.SetDefault(BlockchainEnabledKey, true)
-	vip.SetDefault(ConfigPathKey, "snetd.config")
-	vip.SetDefault(DaemonListeningPortKey, 5000)
-	vip.SetDefault(DaemonTypeKey, "grpc")
-	vip.SetDefault(DbPathKey, "snetd.db")
-	vip.SetDefault(EthereumJsonRpcEndpointKey, "http://127.0.0.1:8545")
-	vip.SetDefault(HdwalletIndexKey, 0)
 	vip.SetDefault(LogLevelKey, 5)
-	vip.SetDefault(PassthroughEnabledKey, false)
-	vip.SetDefault(PollSleepSecsKey, time.Duration(5))
-	vip.SetDefault(ServiceTypeKey, "grpc")
-	vip.SetDefault(WireEncodingKey, "proto")
 
 	vip.SetConfigName(vip.GetString(ConfigPathKey))
 
 	vip.AddConfigPath(".")
-	err := vip.ReadInConfig()
-	if err != nil {
-		log.WithError(err).Debug("error reading config")
-	}
+}
+
+func Vip() *viper.Viper {
+	return vip
+}
+
+func Read() error {
+	return vip.ReadInConfig()
 }
 
 func Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ const (
 	LogLevelKey                = "LOG_LEVEL"
 	PassthroughEnabledKey      = "PASSTHROUGH_ENABLED"
 	PassthroughEndpointKey     = "PASSTHROUGH_ENDPOINT"
-	PollSleepSecsKey           = "POLL_SLEEP_SECS"
+	PollSleepKey               = "POLL_SLEEP"
 	PrivateKeyKey              = "PRIVATE_KEY"
 	ServiceTypeKey             = "SERVICE_TYPE"
 	WireEncodingKey            = "WIRE_ENCODING"
@@ -37,17 +37,11 @@ func init() {
 
 	vip.SetDefault(LogLevelKey, 5)
 
-	vip.SetConfigName(vip.GetString(ConfigPathKey))
-
 	vip.AddConfigPath(".")
 }
 
 func Vip() *viper.Viper {
 	return vip
-}
-
-func Read() error {
-	return vip.ReadInConfig()
 }
 
 func Validate() error {

--- a/resources/test/main_test.go
+++ b/resources/test/main_test.go
@@ -44,7 +44,7 @@ var testConfiguration = []string{
 	"SNET_HDWALLET_INDEX=0",
 	"SNET_LOG_LEVEL=5",
 	"SNET_PASSTHROUGH_ENABLED=false",
-	"SNET_POLL_SLEEP_SECS=1",
+	"SNET_POLL_SLEEP=1s",
 	"SNET_SERVICE_TYPE=grpc",
 	"SMET_WIRE_ENCODING=json",
 }

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/singnet/snet-daemon/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cfgFile            = ServeCmd.PersistentFlags().StringP("config", "c", "snetd.config", "config file")
+	daemonType         = ServeCmd.PersistentFlags().StringP("type", "t", "grpc", "daemon type: one of 'grpc','http'")
+	blockchainEnabled  = ServeCmd.PersistentFlags().BoolP("blockchain", "b", true, "enable blockchain processing")
+	listenPort         = ServeCmd.PersistentFlags().IntP("port", "p", 5000, "daemon listen port")
+	ethEndpoint        = ServeCmd.PersistentFlags().String("ethereum-endpoint", "http://127.0.0.1:8545", "ethereum JSON-RPC endpoint")
+	mnemonic           = ServeCmd.PersistentFlags().String("mnemonic", "", "HD wallet mnemonic")
+	hdwIndex           = ServeCmd.PersistentFlags().Int("wallet-index", 0, "HD wallet index")
+	dbPath             = ServeCmd.PersistentFlags().String("db-path", "snetd.db", "database file path")
+	passthroughEnabled = ServeCmd.PersistentFlags().Bool("passthrough", false, "passthrough mode")
+	serviceType        = ServeCmd.PersistentFlags().String("service-type", "grpc", "service type: one of 'grpc','jsonrpc','process'")
+	wireEncoding       = ServeCmd.PersistentFlags().String("wire-encoding", "proto", "message encoding: one of 'proto','json'")
+	pollSleep          = ServeCmd.PersistentFlags().String("poll-sleep", "5s", "blockchain poll sleep time")
+)
+
+func init() {
+	rf := ServeCmd.PersistentFlags()
+	vip := config.Vip()
+
+	vip.BindPFlag(config.ConfigPathKey, rf.Lookup("config"))
+	vip.BindPFlag(config.DaemonTypeKey, rf.Lookup("type"))
+	vip.BindPFlag(config.BlockchainEnabledKey, rf.Lookup("blockchain"))
+	vip.BindPFlag(config.DaemonListeningPortKey, rf.Lookup("port"))
+	vip.BindPFlag(config.EthereumJsonRpcEndpointKey, rf.Lookup("ethereum-endpoint"))
+	vip.BindPFlag(config.HdwalletMnemonicKey, rf.Lookup("mnemonic"))
+	vip.BindPFlag(config.HdwalletIndexKey, rf.Lookup("wallet-index"))
+	vip.BindPFlag(config.DbPathKey, rf.Lookup("db-path"))
+	vip.BindPFlag(config.PassthroughEnabledKey, rf.Lookup("passthrough"))
+	vip.BindPFlag(config.ServiceTypeKey, rf.Lookup("service-type"))
+	vip.BindPFlag(config.WireEncodingKey, rf.Lookup("wire-encoding"))
+	vip.BindPFlag(config.PollSleepSecsKey, rf.Lookup("poll-sleep"))
+
+	cobra.OnInitialize(func() {
+		vip.SetConfigName(*cfgFile)
+
+		if err := config.Read(); err != nil {
+			log.WithError(err).Debug("error reading config")
+		}
+	})
+}

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	cfgFile            = ServeCmd.PersistentFlags().StringP("config", "c", "snetd.config", "config file")
+	cfgFile            = ServeCmd.PersistentFlags().StringP("config", "c", "snetd.config.json", "config file")
 	daemonType         = ServeCmd.PersistentFlags().StringP("type", "t", "grpc", "daemon type: one of 'grpc','http'")
 	blockchainEnabled  = ServeCmd.PersistentFlags().BoolP("blockchain", "b", true, "enable blockchain processing")
 	listenPort         = ServeCmd.PersistentFlags().IntP("port", "p", 5000, "daemon listen port")
@@ -36,12 +36,12 @@ func init() {
 	vip.BindPFlag(config.PassthroughEnabledKey, rf.Lookup("passthrough"))
 	vip.BindPFlag(config.ServiceTypeKey, rf.Lookup("service-type"))
 	vip.BindPFlag(config.WireEncodingKey, rf.Lookup("wire-encoding"))
-	vip.BindPFlag(config.PollSleepSecsKey, rf.Lookup("poll-sleep"))
+	vip.BindPFlag(config.PollSleepKey, rf.Lookup("poll-sleep"))
 
 	cobra.OnInitialize(func() {
-		vip.SetConfigName(*cfgFile)
+		vip.SetConfigFile(*cfgFile)
 
-		if err := config.Read(); err != nil {
+		if err := vip.ReadInConfig(); err != nil {
 			log.WithError(err).Debug("error reading config")
 		}
 	})


### PR DESCRIPTION
These are bound with cobra/viper, so you can still set them (and fetch
them) via viper (hence no code changes to config fetching). But now you
can also specify them on the command line, and `snetd --help` will show
available flags.

```
go run ./snetd/main.go --help
Usage:
  snetd [flags]

Flags:
  -b, --blockchain                 enable blockchain processing (default true)
  -c, --config string              config file (default "snetd.config")
      --db-path string             database file path (default "snetd.db")
      --ethereum-endpoint string   ethereum JSON-RPC endpoint (default "http://127.0.0.1:8545")
  -h, --help                       help for snetd
      --mnemonic string            HD wallet mnemonic
      --passthrough                passthrough mode
      --poll-sleep string          blockchain poll sleep time (default "5s")
  -p, --port int                   daemon listen port (default 5000)
      --service-type string        service type: one of 'grpc','jsonrpc','process' (default "grpc")
  -t, --type string                daemon type: one of 'grpc','http' (default "grpc")
      --wallet-index int           HD wallet index
      --wire-encoding string       message encoding: one of 'proto','json' (default "proto")
```

```
go run ./snetd/main.go -t foo
DEBU[0000] error reading config                          error="Config File \"snetd.config\" Not Found in \"[/home/aiden/src/go/src/github.com/singnet/snet-daemon]\""
ERRO[0000] Unable to initialize daemon                   error="unrecognized DAEMON_TYPE 'foo'"
exit status 2
```