### PR TITLE
Add SSL/TLS and LetsEncrypt autocert support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -283,6 +283,8 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [
+    "acme",
+    "acme/autocert",
     "pbkdf2",
     "ripemd160",
     "scrypt",
@@ -409,6 +411,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cbc7a4f937c23368b0c231c23fb2ca3e7fc51d17b01b4fadbdef11da4e5bba5b"
+  inputs-digest = "14792d968a10c400e5ad053f4b66fd8295162b1cc4c097ce8666965e0043a49e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,3 +57,7 @@
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/crypto"

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,8 @@ import (
 
 const (
 	AgentContractAddressKey    = "AGENT_CONTRACT_ADDRESS"
+	AutoSSLDomainKey           = "AUTO_SSL_DOMAIN"
+	AutoSSLCacheDirKey         = "AUTO_SSL_CACHE_DIR"
 	BlockchainEnabledKey       = "BLOCKCHAIN_ENABLED"
 	ConfigPathKey              = "CONFIG_PATH"
 	DaemonListeningPortKey     = "DAEMON_LISTENING_PORT"

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -8,6 +8,8 @@ import (
 
 var (
 	cfgFile            = ServeCmd.PersistentFlags().StringP("config", "c", "snetd.config.json", "config file")
+	autoSSLDomain      = ServeCmd.PersistentFlags().String("auto-ssl-domain", "", "enable SSL via LetsEncrypt for this domain (requires root)")
+	autoSSLCacheDir    = ServeCmd.PersistentFlags().String("auto-ssl-cache", ".certs", "auto-SSL certificate cache directory")
 	daemonType         = ServeCmd.PersistentFlags().StringP("type", "t", "grpc", "daemon type: one of 'grpc','http'")
 	blockchainEnabled  = ServeCmd.PersistentFlags().BoolP("blockchain", "b", true, "enable blockchain processing")
 	listenPort         = ServeCmd.PersistentFlags().IntP("port", "p", 5000, "daemon listen port")
@@ -26,6 +28,8 @@ func init() {
 	vip := config.Vip()
 
 	vip.BindPFlag(config.ConfigPathKey, rf.Lookup("config"))
+	vip.BindPFlag(config.AutoSSLDomainKey, rf.Lookup("auto-ssl-domain"))
+	vip.BindPFlag(config.AutoSSLCacheDirKey, rf.Lookup("auto-ssl-cache"))
 	vip.BindPFlag(config.DaemonTypeKey, rf.Lookup("type"))
 	vip.BindPFlag(config.BlockchainEnabledKey, rf.Lookup("blockchain"))
 	vip.BindPFlag(config.DaemonListeningPortKey, rf.Lookup("port"))


### PR DESCRIPTION
This change adds automatic SSL support via LetsEncrypt ("http-01"
challenge, since tls-sni- challenges were disabled recently for
security issues).

If requested, the daemon now fetches certs and serves gRPC/HTTP over TLS
when requested.