### PR TITLE
Use dynamic TCP ports for test run

### DIFF
--- a/resources/blockchain/truffle.js
+++ b/resources/blockchain/truffle.js
@@ -9,15 +9,17 @@ let provider = (endpoint) => {
     }
 };
 
+const ganachePort = parseInt(process.env.DAEMON_GANACHE_PORT || 8545);
+
 module.exports = {
     networks: {
         local: {
             host: "127.0.0.1",
-            port: 8545,
+            port: ganachePort,
             network_id: "*" // Any network ID
         },
         localhd: {
-            provider: () => provider("http://127.0.0.1:8545"),
+            provider: () => provider("http://127.0.0.1:" + ganachePort),
             network_id: "*" // Any network ID
         },
         kovan: {


### PR DESCRIPTION
This way, you can have multiple test runs on the same machine, or have a
local ganache/daemon running on the standard ports for development and
still be able to run the tests.

While in here, trim redundant daemon environment variables.