### PR TITLE
Add ```snetd init``` command to save default configuration file.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,10 @@ func Validate() error {
 	return nil
 }
 
+func WriteConfig() error {
+	return vip.WriteConfig()
+}
+
 func GetString(key string) string {
 	return vip.GetString(key)
 }

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,7 +51,9 @@ func init() {
 		vip.SetConfigFile(*cfgFile)
 
 		if err := vip.ReadInConfig(); err != nil {
-			log.WithError(err).Debug("error reading config")
+			fmt.Println("Error reading config", err)
 		}
+
+		log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
 	})
 }

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -9,6 +9,13 @@ import (
 
 var RootCmd = &cobra.Command{
 	Use: "snetd",
+	Run: func(cmd *cobra.Command, args []string) {
+		if command, _, err := cmd.Find(args); err != nil && command != nil {
+			command.Execute()
+		} else {
+			ServeCmd.Run(cmd, args)
+		}
+	},
 }
 
 var (

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -5,6 +5,7 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var RootCmd = &cobra.Command{
@@ -63,12 +64,16 @@ func init() {
 	cobra.OnInitialize(func() {
 		vip.SetConfigFile(*cfgFile)
 
-		if err := vip.ReadInConfig(); err != nil {
-			fmt.Println("Error reading config", err)
+		if RootCmd.PersistentFlags().Lookup("config").Changed {
+			if err := vip.ReadInConfig(); err != nil {
+				fmt.Println("Error reading config:", *cfgFile, err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Println("Configuration file is not set, using default configuration")
 		}
 
 		log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
-
 		log.Info("Cobra initialized")
 	})
 }

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -7,8 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var RootCmd = &cobra.Command{
+	Use: "snetd",
+}
+
 var (
-	cfgFile            = ServeCmd.PersistentFlags().StringP("config", "c", "snetd.config.json", "config file")
+	cfgFile            = RootCmd.PersistentFlags().StringP("config", "c", "snetd.config.json", "config file")
 	autoSSLDomain      = ServeCmd.PersistentFlags().String("auto-ssl-domain", "", "enable SSL via LetsEncrypt for this domain (requires root)")
 	autoSSLCacheDir    = ServeCmd.PersistentFlags().String("auto-ssl-cache", ".certs", "auto-SSL certificate cache directory")
 	daemonType         = ServeCmd.PersistentFlags().StringP("type", "t", "grpc", "daemon type: one of 'grpc','http'")
@@ -27,25 +31,27 @@ var (
 )
 
 func init() {
-	rf := ServeCmd.PersistentFlags()
+	serveCmdFlags := ServeCmd.PersistentFlags()
 	vip := config.Vip()
 
-	vip.BindPFlag(config.ConfigPathKey, rf.Lookup("config"))
-	vip.BindPFlag(config.AutoSSLDomainKey, rf.Lookup("auto-ssl-domain"))
-	vip.BindPFlag(config.AutoSSLCacheDirKey, rf.Lookup("auto-ssl-cache"))
-	vip.BindPFlag(config.DaemonTypeKey, rf.Lookup("type"))
-	vip.BindPFlag(config.BlockchainEnabledKey, rf.Lookup("blockchain"))
-	vip.BindPFlag(config.DaemonListeningPortKey, rf.Lookup("port"))
-	vip.BindPFlag(config.EthereumJsonRpcEndpointKey, rf.Lookup("ethereum-endpoint"))
-	vip.BindPFlag(config.HdwalletMnemonicKey, rf.Lookup("mnemonic"))
-	vip.BindPFlag(config.HdwalletIndexKey, rf.Lookup("wallet-index"))
-	vip.BindPFlag(config.DbPathKey, rf.Lookup("db-path"))
-	vip.BindPFlag(config.PassthroughEnabledKey, rf.Lookup("passthrough"))
-	vip.BindPFlag(config.ServiceTypeKey, rf.Lookup("service-type"))
-	vip.BindPFlag(config.SSLCertPathKey, rf.Lookup("ssl-cert"))
-	vip.BindPFlag(config.SSLKeyPathKey, rf.Lookup("ssl-key"))
-	vip.BindPFlag(config.WireEncodingKey, rf.Lookup("wire-encoding"))
-	vip.BindPFlag(config.PollSleepKey, rf.Lookup("poll-sleep"))
+	RootCmd.AddCommand(InitCmd)
+	RootCmd.AddCommand(ServeCmd)
+
+	vip.BindPFlag(config.AutoSSLDomainKey, serveCmdFlags.Lookup("auto-ssl-domain"))
+	vip.BindPFlag(config.AutoSSLCacheDirKey, serveCmdFlags.Lookup("auto-ssl-cache"))
+	vip.BindPFlag(config.DaemonTypeKey, serveCmdFlags.Lookup("type"))
+	vip.BindPFlag(config.BlockchainEnabledKey, serveCmdFlags.Lookup("blockchain"))
+	vip.BindPFlag(config.DaemonListeningPortKey, serveCmdFlags.Lookup("port"))
+	vip.BindPFlag(config.EthereumJsonRpcEndpointKey, serveCmdFlags.Lookup("ethereum-endpoint"))
+	vip.BindPFlag(config.HdwalletMnemonicKey, serveCmdFlags.Lookup("mnemonic"))
+	vip.BindPFlag(config.HdwalletIndexKey, serveCmdFlags.Lookup("wallet-index"))
+	vip.BindPFlag(config.DbPathKey, serveCmdFlags.Lookup("db-path"))
+	vip.BindPFlag(config.PassthroughEnabledKey, serveCmdFlags.Lookup("passthrough"))
+	vip.BindPFlag(config.ServiceTypeKey, serveCmdFlags.Lookup("service-type"))
+	vip.BindPFlag(config.SSLCertPathKey, serveCmdFlags.Lookup("ssl-cert"))
+	vip.BindPFlag(config.SSLKeyPathKey, serveCmdFlags.Lookup("ssl-key"))
+	vip.BindPFlag(config.WireEncodingKey, serveCmdFlags.Lookup("wire-encoding"))
+	vip.BindPFlag(config.PollSleepKey, serveCmdFlags.Lookup("poll-sleep"))
 
 	cobra.OnInitialize(func() {
 		vip.SetConfigFile(*cfgFile)
@@ -55,5 +61,7 @@ func init() {
 		}
 
 		log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
+
+		log.Info("Cobra initialized")
 	})
 }

--- a/snetd/cmd/init.go
+++ b/snetd/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var InitCmd = &cobra.Command{
@@ -14,6 +15,7 @@ var InitCmd = &cobra.Command{
 		log.Info("Writing default configuration")
 		if err := config.WriteConfig(); err != nil {
 			log.WithError(err).Error("Cannot write default configuration")
+			os.Exit(1)
 		}
 	},
 }

--- a/snetd/cmd/init.go
+++ b/snetd/cmd/init.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/singnet/snet-daemon/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var InitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Write default configuration to file",
+	Long:  "Use this command to create default configuration file. Then update the file with your settings.",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Info("Writing default configuration")
+		if err := config.WriteConfig(); err != nil {
+			log.WithError(err).Error("Cannot write default configuration")
+		}
+	},
+}

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -31,7 +31,7 @@ var corsOptions = []handlers.CORSOption{
 }
 
 var ServeCmd = &cobra.Command{
-	Use: "snetd",
+	Use: "serve",
 	Run: func(cmd *cobra.Command, args []string) {
 		d, err := newDaemon()
 		if err != nil {

--- a/snetd/main.go
+++ b/snetd/main.go
@@ -9,8 +9,8 @@ import (
 )
 
 func main() {
-	if err := cmd.ServeCmd.Execute(); err != nil {
-		log.WithError(err).Error("Unable to serve")
+	if err := cmd.RootCmd.Execute(); err != nil {
+		log.WithError(err).Error("Unable to run application")
 		os.Exit(1)
 	}
 }

--- a/snetd/main.go
+++ b/snetd/main.go
@@ -3,15 +3,12 @@ package main
 import (
 	"os"
 
-	"github.com/singnet/snet-daemon/config"
 	"github.com/singnet/snet-daemon/snetd/cmd"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func main() {
-	log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
-
 	if err := cmd.ServeCmd.Execute(); err != nil {
 		log.WithError(err).Error("Unable to serve")
 		os.Exit(1)


### PR DESCRIPTION
- initialize logger after loading configuration from file
- add root Cobra command and two children: ```serve``` and ```init```
- implement ```init``` to save config to file specified
- make ```snetd``` run ```serve``` by default for backward compatibility