### PR TITLE
Fix resource test package

### DIFF
--- a/resources/test/grpc.go
+++ b/resources/test/grpc.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"context"

--- a/resources/test/grpc_web.go
+++ b/resources/test/grpc_web.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"bytes"

--- a/resources/test/harness.go
+++ b/resources/test/harness.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"encoding/json"

--- a/resources/test/harness.go
+++ b/resources/test/harness.go
@@ -21,6 +21,14 @@ type harness struct {
 	buildStatePath string
 }
 
+type jobFile struct {
+	Job string
+}
+
+type jobInvocationFile struct {
+	Signature string
+}
+
 func (h harness) createSignedJob() signedJob {
 	runCommand(h.blockchainPath, h.truffleEnv, "npm", "run", "create-job").Wait()
 	runCommand(h.blockchainPath, h.truffleEnv, "npm", "run", "fund-job").Wait()

--- a/resources/test/main_test.go
+++ b/resources/test/main_test.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"encoding/json"

--- a/resources/test/main_test.go
+++ b/resources/test/main_test.go
@@ -4,11 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -24,14 +21,6 @@ type mnemonicFile struct {
 
 type agentFile struct {
 	Agent string
-}
-
-type jobFile struct {
-	Job string
-}
-
-type jobInvocationFile struct {
-	Signature string
 }
 
 var testConfiguration = []string{
@@ -123,33 +112,4 @@ func TestEndToEnd(t *testing.T) {
 	header("Testing gRPC-web client")
 	testGRPCWeb(t, h, daemonPort)
 	time.Sleep(time.Second)
-}
-
-func runCommand(dir string, env []string, name string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(name, arg...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	if env != nil && len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
-	}
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Start()
-	return cmd
-}
-
-func pickAvailablePort() string {
-	p, err := net.Listen("tcp", ":0")
-	if err != nil {
-		panic(err)
-	}
-	addr := p.Addr().String()
-	parts := strings.Split(addr, ":")
-	if len(parts) < 2 {
-		panic("Can't parse address: " + addr)
-	}
-	p.Close()
-
-	return parts[len(parts)-1]
 }

--- a/resources/test/utility.go
+++ b/resources/test/utility.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCommand(dir string, env []string, name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if env != nil && len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Start()
+	return cmd
+}
+
+func pickAvailablePort() string {
+	p, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+	addr := p.Addr().String()
+	parts := strings.Split(addr, ":")
+	if len(parts) < 2 {
+		panic("Can't parse address: " + addr)
+	}
+	p.Close()
+
+	return parts[len(parts)-1]
+}

--- a/resources/test/utility.go
+++ b/resources/test/utility.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"net"


### PR DESCRIPTION
Fix package name and internal functions definition places to allow ```go build``` and such tools as ```gorename``` working without issues.