### PR TITLE
Fix read default config if file exist

### DIFF
--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -69,6 +69,7 @@ func init() {
 				fmt.Println("Error reading config:", *cfgFile, err)
 				os.Exit(1)
 			}
+			fmt.Printf("Using configuration from \"%v\" file\n", *cfgFile)
 		} else {
 			fmt.Println("Configuration file is not set, using default configuration")
 		}

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -64,7 +64,7 @@ func init() {
 	cobra.OnInitialize(func() {
 		vip.SetConfigFile(*cfgFile)
 
-		if RootCmd.PersistentFlags().Lookup("config").Changed {
+		if RootCmd.PersistentFlags().Lookup("config").Changed || isFileExist(*cfgFile) {
 			if err := vip.ReadInConfig(); err != nil {
 				fmt.Println("Error reading config:", *cfgFile, err)
 				os.Exit(1)
@@ -76,4 +76,12 @@ func init() {
 		log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
 		log.Info("Cobra initialized")
 	})
+}
+
+func isFileExist(file string) bool {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return false
+	} else {
+		return true
+	}
 }

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -79,10 +79,7 @@ func init() {
 	})
 }
 
-func isFileExist(file string) bool {
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return false
-	} else {
-		return true
-	}
+func isFileExist(fileName string) bool {
+	_, err := os.Stat(fileName)
+	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
Fix case when user doesn't specify configuration file but default configuration file ```snetd.config.json``` exists in filesystem. Before fix snet-daemon ignored this file.