### PR TITLE
Trigger platform-pipeline build after successful execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     docker:
       - image: circleci/golang:1.9-node
     working_directory: /go/src/github.com/singnet/snet-daemon
+    environment:
+      TRIGGER_BUILD_BRANCH: master
     steps:
       - checkout
       - run:
@@ -26,3 +28,9 @@ jobs:
       - run:
           name: Run test script
           command: ./scripts/test
+      - run:
+          name: Trigger platform-pipeline build
+          command: |
+            curl -u ${CIRCLECI_PLATFORM_PIPELINE_TOKEN}: \
+              -d build_parameters[CIRCLE_JOB]=build \
+              https://circleci.com/api/v1.1/project/github/singnet/platform-pipeline/tree/${TRIGGER_BUILD_BRANCH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
       - run:
           name: Trigger platform-pipeline build
           command: |
-            curl -u ${CIRCLECI_PLATFORM_PIPELINE_TOKEN}: \
-              -d build_parameters[CIRCLE_JOB]=build \
-              https://circleci.com/api/v1.1/project/github/singnet/platform-pipeline/tree/${TRIGGER_BUILD_BRANCH}
+            if [ "$CIRCLE_BRANCH" == "$TRIGGER_BUILD_BRANCH" ]
+            then
+              curl -u ${CIRCLECI_PLATFORM_PIPELINE_TOKEN}: \
+                -d build_parameters[CIRCLE_JOB]=build \
+                https://circleci.com/api/v1.1/project/github/singnet/platform-pipeline/tree/${TRIGGER_BUILD_BRANCH}
+            fi


### PR DESCRIPTION
The fix allows to trigger the platform-pipeline after the current build successful execution.

It requires that in the CircleCI dashboard:
1. A token with name  CIRCLECI_PLATFORM_PIPELINE_TOKEN is created 
 Workflows -> platform-pipeline -> Settings -> API Permissions with necessary permissions.
2. The CIRCLECI_PLATFORM_PIPELINE_TOKEN env variable is added to the snet-daemon 
Workflows -> snet-daemon-> Settings ->Environment Variables