### PR TITLE
Load configuration only when starting daemon.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,13 @@ func Validate() error {
 	return nil
 }
 
-func WriteConfig() error {
+func LoadConfig(configFile string) error {
+	vip.SetConfigFile(configFile)
+	return vip.ReadInConfig()
+}
+
+func WriteConfig(configFile string) error {
+	vip.SetConfigFile(configFile)
 	return vip.WriteConfig()
 }
 

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -62,24 +61,10 @@ func init() {
 	vip.BindPFlag(config.PollSleepKey, serveCmdFlags.Lookup("poll-sleep"))
 
 	cobra.OnInitialize(func() {
-		vip.SetConfigFile(*cfgFile)
 
-		if RootCmd.PersistentFlags().Lookup("config").Changed || isFileExist(*cfgFile) {
-			if err := vip.ReadInConfig(); err != nil {
-				fmt.Println("Error reading config:", *cfgFile, err)
-				os.Exit(1)
-			}
-			fmt.Printf("Using configuration from \"%v\" file\n", *cfgFile)
-		} else {
-			fmt.Println("Configuration file is not set, using default configuration")
-		}
+		log.SetOutput(os.Stdout)
+		log.SetLevel(log.InfoLevel)
 
-		log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
 		log.Info("Cobra initialized")
 	})
-}
-
-func isFileExist(fileName string) bool {
-	_, err := os.Stat(fileName)
-	return !os.IsNotExist(err)
 }

--- a/snetd/cmd/init.go
+++ b/snetd/cmd/init.go
@@ -4,7 +4,6 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var InitCmd = &cobra.Command{
@@ -12,10 +11,14 @@ var InitCmd = &cobra.Command{
 	Short: "Write default configuration to file",
 	Long:  "Use this command to create default configuration file. Then update the file with your settings.",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Info("Writing default configuration")
-		if err := config.WriteConfig(); err != nil {
-			log.WithError(err).Error("Cannot write default configuration")
-			os.Exit(1)
+		var err error
+		var configFile = cmd.Flags().Lookup("config").Value.String()
+
+		log.WithField("configFile", configFile).Info("Writing default configuration to the file")
+
+		err = config.WriteConfig(configFile)
+		if err != nil {
+			log.WithError(err).WithField("configFile", configFile).Fatal("Cannot write default configuration")
 		}
 	},
 }


### PR DESCRIPTION
Move loading configuration and logger initialization out of cobra
initialization. The reason is not all of commands need load
configuration and initialize logger. ```snetd init``` for instance
doesn't need it.