### PR TITLE
Issue #27: add logger configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ const (
 	HdwalletIndexKey           = "HDWALLET_INDEX"
 	HdwalletMnemonicKey        = "HDWALLET_MNEMONIC"
 	LogLevelKey                = "LOG.LEVEL"
+	LogFormatterKey            = "LOG.FORMATTER"
 	PassthroughEnabledKey      = "PASSTHROUGH_ENABLED"
 	PassthroughEndpointKey     = "PASSTHROUGH_ENDPOINT"
 	PollSleepKey               = "POLL_SLEEP"
@@ -53,7 +54,7 @@ const (
 		"level": "info",
 		"formatter": {
 			"type": "json",
-			"timestamp_timezone": "UTC"
+			"timezone": "UTC"
 		},
 		"output": {
 			"type": "file",

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func init() {
 	vip.AutomaticEnv()
 
 	defaults = viper.New()
-	err = readConfigurationFromJsonString(defaults, defaultConfigJson)
+	err = ReadConfigFromJsonString(defaults, defaultConfigJson)
 	if err != nil {
 		panic(fmt.Sprintf("Cannot load default config: %v", err))
 	}
@@ -89,7 +89,7 @@ func init() {
 	vip.AddConfigPath(".")
 }
 
-func readConfigurationFromJsonString(config *viper.Viper, json string) error {
+func ReadConfigFromJsonString(config *viper.Viper, json string) error {
 	config.SetConfigType("json")
 	return config.ReadConfig(strings.NewReader(json))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,8 @@ func init() {
 	vip.AddConfigPath(".")
 }
 
+// ReadConfigFromJsonString function reads settigs from json string to the
+// config instance. String should contain valid JSON config.
 func ReadConfigFromJsonString(config *viper.Viper, json string) error {
 	config.SetConfigType("json")
 	return config.ReadConfig(strings.NewReader(json))

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ const (
 	HdwalletMnemonicKey        = "HDWALLET_MNEMONIC"
 	LogLevelKey                = "LOG.LEVEL"
 	LogFormatterKey            = "LOG.FORMATTER"
+	LogOutputKey               = "LOG.OUTPUT"
 	PassthroughEnabledKey      = "PASSTHROUGH_ENABLED"
 	PassthroughEndpointKey     = "PASSTHROUGH_ENDPOINT"
 	PollSleepKey               = "POLL_SLEEP"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,19 @@
+package logger
+
+import (
+	"github.com/singnet/snet-daemon/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func InitLogger() {
+	var err error
+	var logLevel log.Level
+	var settings = config.GetString(config.LogLevelKey)
+
+	logLevel, err = log.ParseLevel(settings)
+	if err != nil {
+		log.WithError(err).WithField("settings", settings).Fatal("Cannot parse log level value from settings")
+	}
+
+	log.SetLevel(logLevel)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,34 +2,51 @@ package logger
 
 import (
 	"fmt"
+	"github.com/lestrrat-go/file-rotatelogs"
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"io"
+	"os"
 	"time"
 )
 
 const (
-	LogFormatterTypeKey     = "type"
-	LogFormatterTimezoneKey = "timezone"
+	LogFormatterTypeKey            = "type"
+	LogFormatterTimezoneKey        = "timezone"
+	LogOutputTypeKey               = "type"
+	LogOutputFileFilePattern       = "file_pattern"
+	LogOutputFileCurrentLink       = "current_link"
+	LogOutputFileClockTimezone     = "clock_timezone"
+	LogOutputFileRotationTimeInSec = "rotation_time_in_sec"
+	LogOutputFileMaxAgeInSec       = "max_age_in_sec"
+	LogOutputFileRotationCount     = "rotation_count"
 )
 
 func InitLogger() error {
 	var err error
 
-	var logLevel log.Level
-	var logLevelConfig = config.GetString(config.LogLevelKey)
-	logLevel, err = log.ParseLevel(logLevelConfig)
+	var level log.Level
+	var levelString = config.GetString(config.LogLevelKey)
+	level, err = log.ParseLevel(levelString)
 	if err != nil {
-		return fmt.Errorf("Unable parse log level value: %v, err: %v", logLevelConfig, err)
+		return fmt.Errorf("Unable parse log level string: %v, err: %v", levelString, err)
 	}
-	log.SetLevel(logLevel)
+	log.SetLevel(level)
 
 	var formatter log.Formatter
 	formatter, err = newFormatterByConfig(config.Vip().Sub(config.LogFormatterKey))
 	if err != nil {
-		return fmt.Errorf("Unable initialize formatter, error: %v", err)
+		return fmt.Errorf("Unable initialize log formatter, error: %v", err)
 	}
 	log.SetFormatter(formatter)
+
+	var output io.Writer
+	output, err = newOutputByConfig(config.Vip().Sub(config.LogOutputKey))
+	if err != nil {
+		return fmt.Errorf("Unable initialize log output, error: %v, err")
+	}
+	log.SetOutput(output)
 
 	return nil
 }
@@ -68,4 +85,45 @@ type timezoneFormatter struct {
 func (formatter *timezoneFormatter) Format(entry *log.Entry) ([]byte, error) {
 	entry.Time = entry.Time.In(formatter.timestampLocation)
 	return formatter.delegate.Format(entry)
+}
+
+func newOutputByConfig(config *viper.Viper) (io.Writer, error) {
+	var err error
+
+	config.SetDefault(LogOutputTypeKey, "file")
+
+	switch outputType := config.GetString(LogOutputTypeKey); outputType {
+	case "file":
+
+		config.SetDefault(LogOutputFileFilePattern, "./snet-daemon.%Y%m%d.metrics.log")
+		config.SetDefault(LogOutputFileClockTimezone, time.Local.String())
+		config.SetDefault(LogOutputFileCurrentLink, "")
+		config.SetDefault(LogOutputFileRotationTimeInSec, 86400)
+		config.SetDefault(LogOutputFileMaxAgeInSec, 604800)
+		config.SetDefault(LogOutputFileRotationCount, 0)
+
+		var location *time.Location
+		if location, err = time.LoadLocation(config.GetString(LogOutputFileClockTimezone)); err != nil {
+			return nil, err
+		}
+
+		var fileWriter io.Writer
+		fileWriter, err = rotatelogs.New(config.GetString(LogOutputFileFilePattern),
+			rotatelogs.WithLocation(location),
+			rotatelogs.WithLinkName(config.GetString(LogOutputFileCurrentLink)),
+			rotatelogs.WithRotationTime(config.GetDuration(LogOutputFileRotationTimeInSec)),
+			rotatelogs.WithMaxAge(config.GetDuration(LogOutputFileMaxAgeInSec)),
+			rotatelogs.WithRotationCount(uint(config.GetInt(LogOutputFileRotationCount))),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return fileWriter, nil
+	case "stdout":
+		return os.Stdout, nil
+	default:
+		return nil, fmt.Errorf("Unexpected output type: %v", outputType)
+	}
+
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -91,7 +91,7 @@ func initLogger(config *configWithDefaults) error {
 	var output io.Writer
 	output, err = newOutputByConfig(config.sub(LogOutputKey))
 	if err != nil {
-		return fmt.Errorf("Unable initialize log output, error: %v, err")
+		return fmt.Errorf("Unable initialize log output, error: %v", err)
 	}
 	log.SetOutput(output)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,19 +1,71 @@
 package logger
 
 import (
+	"fmt"
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"time"
 )
 
-func InitLogger() {
-	var err error
-	var logLevel log.Level
-	var settings = config.GetString(config.LogLevelKey)
+const (
+	LogFormatterTypeKey     = "type"
+	LogFormatterTimezoneKey = "timezone"
+)
 
-	logLevel, err = log.ParseLevel(settings)
+func InitLogger() error {
+	var err error
+
+	var logLevel log.Level
+	var logLevelConfig = config.GetString(config.LogLevelKey)
+	logLevel, err = log.ParseLevel(logLevelConfig)
 	if err != nil {
-		log.WithError(err).WithField("settings", settings).Fatal("Cannot parse log level value from settings")
+		return fmt.Errorf("Unable parse log level value: %v, err: %v", logLevelConfig, err)
+	}
+	log.SetLevel(logLevel)
+
+	var formatter log.Formatter
+	formatter, err = newFormatterByConfig(config.Vip().Sub(config.LogFormatterKey))
+	if err != nil {
+		return fmt.Errorf("Unable initialize formatter, error: %v", err)
+	}
+	log.SetFormatter(formatter)
+
+	return nil
+}
+
+func newFormatterByConfig(config *viper.Viper) (*timezoneFormatter, error) {
+	var err error
+	var formatter *timezoneFormatter = &timezoneFormatter{}
+
+	config.SetDefault(LogFormatterTypeKey, "json")
+	config.SetDefault(LogFormatterTimezoneKey, time.Local.String())
+
+	switch formatterType := config.GetString(LogFormatterTypeKey); formatterType {
+	case "text":
+		formatter.delegate = &log.TextFormatter{}
+	case "json":
+		formatter.delegate = &log.JSONFormatter{}
+	default:
+		return nil, fmt.Errorf("Unexpected formatter type: %v", formatterType)
 	}
 
-	log.SetLevel(logLevel)
+	var location *time.Location
+	location, err = time.LoadLocation(config.GetString(LogFormatterTimezoneKey))
+	if err != nil {
+		return nil, err
+	}
+	formatter.timestampLocation = location
+
+	return formatter, nil
+}
+
+type timezoneFormatter struct {
+	delegate          log.Formatter
+	timestampLocation *time.Location
+}
+
+func (formatter *timezoneFormatter) Format(entry *log.Entry) ([]byte, error) {
+	entry.Time = entry.Time.In(formatter.timestampLocation)
+	return formatter.delegate.Format(entry)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// Logger configuration keys
 const (
 	LogLevelKey     = "level"
 	LogFormatterKey = "formatter"
@@ -49,9 +50,8 @@ type configWithDefaults struct {
 func (config *configWithDefaults) get(key string) interface{} {
 	if config.config != nil && config.config.InConfig(key) {
 		return config.config.Get(key)
-	} else {
-		return config.defaults.Get(key)
 	}
+	return config.defaults.Get(key)
 }
 
 func (config *configWithDefaults) getString(key string) string {
@@ -102,7 +102,7 @@ func initLogger(config *configWithDefaults) error {
 
 func newFormatterByConfig(config *configWithDefaults) (*timezoneFormatter, error) {
 	var err error
-	var formatter *timezoneFormatter = &timezoneFormatter{}
+	var formatter = &timezoneFormatter{}
 
 	switch formatterType := config.getString(LogFormatterTypeKey); formatterType {
 	case "text":

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	testConfigJson string = `
+	testConfigJSON string = `
 {
     "json-formatter": {
         "type": "json",
@@ -93,14 +93,14 @@ const (
 var testConfig *viper.Viper
 
 func TestMain(t *testing.T) {
-	testConfig = readConfig(t, testConfigJson)
+	testConfig = readConfig(t, testConfigJSON)
 }
 
-func readConfig(t *testing.T, configJson string) *viper.Viper {
+func readConfig(t *testing.T, configJSON string) *viper.Viper {
 	var err error
 
 	var vip *viper.Viper = viper.New()
-	err = config.ReadConfigFromJsonString(vip, configJson)
+	err = config.ReadConfigFromJsonString(vip, configJSON)
 	if err != nil {
 		t.Fatal("Cannot not read test config", err)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,282 @@
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"github.com/jonboulle/clockwork"
+	"github.com/lestrrat-go/file-rotatelogs"
+	"github.com/singnet/snet-daemon/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	testConfigJson string = `
+{
+    "json-formatter": {
+        "type": "json",
+        "timezone": "UTC"
+    },
+    "text-formatter": {
+        "type": "text",
+        "timezone": "UTC"
+    },
+    "incorrect-type-formatter": {
+        "type": "UNKNOWN"
+    },
+    "incorrect-timezone-formatter": {
+        "type": "text",
+        "timezone": "UNKNOWN"
+    },
+
+    "file-output": {
+        "type": "file",
+        "file_pattern": "./snet-daemon.%Y%m%d.log",
+        "current_link": "./snet-daemon.log",
+        "clock_timezone": "UTC",
+        "rotation_time_in_sec": 86400,
+        "max_age_in_sec": 604800,
+        "rotation_count": 0
+    },
+    "stdout-output": {
+        "type": "stdout"
+    },
+    "incorrect-type-output": {
+        "type": "UNKNOWN"
+    },
+    "incorrect-timezone-output": {
+        "type": "file",
+        "clock_timezone": "UNKNOWN"
+    },
+    "incorrect-file-pattern-output": {
+        "type": "file",
+        "file_pattern": "%5"
+    },
+
+	"log":  {
+		"level": "info",
+		"formatter": {
+			"type": "json",
+			"timezone": "UTC"
+		},
+		"output": {
+			"type": "file",
+			"file_pattern": "./snet-daemon.%Y%m%d.log",
+			"current_link": "./snet-daemon.log",
+			"clock_timezone": "UTC",
+			"rotation_time_in_sec": 86400,
+			"max_age_in_sec": 604800,
+			"rotation_count": 0
+		}
+	},
+	"incorrect-level-log":  {
+		"level": "UNKNOWN"
+	},
+	"incorrect-formatter-log":  {
+		"formatter": {
+			"type": "UNKNOWN"
+		}
+	},
+	"incorrect-output-log":  {
+		"output": {
+			"type": "UNKNOWN"
+		}
+	}
+}
+`
+)
+
+var testConfig *viper.Viper
+
+func TestMain(t *testing.T) {
+	testConfig = readConfig(t, testConfigJson)
+}
+
+func readConfig(t *testing.T, configJson string) *viper.Viper {
+	var err error
+
+	var vip *viper.Viper = viper.New()
+	err = config.ReadConfigFromJsonString(vip, configJson)
+	if err != nil {
+		t.Fatal("Cannot not read test config", err)
+	}
+
+	return vip
+}
+
+func TestNewFormatterTextType(t *testing.T) {
+	var formatterConfig = testConfig.Sub("text-formatter")
+
+	var formatter, err = newFormatterByConfig(&configWithDefaults{formatterConfig, viper.New()})
+
+	assert.Nil(t, err)
+	_, isFormatterDelegate := formatter.delegate.(*log.TextFormatter)
+	assert.True(t, isFormatterDelegate, "Unexpected underlying formatter type, actual: %T, expected: %T", formatter.delegate, &log.TextFormatter{})
+	assert.Equal(t, time.UTC, formatter.timestampLocation, "Incorrect timestampLocation")
+}
+
+func TestNewFormatterJsonType(t *testing.T) {
+	var formatterConfig = testConfig.Sub("json-formatter")
+
+	var formatter, err = newFormatterByConfig(&configWithDefaults{formatterConfig, viper.New()})
+
+	assert.Nil(t, err)
+	_, isFormatterDelegate := formatter.delegate.(*log.JSONFormatter)
+	assert.True(t, isFormatterDelegate, "Unexpected underlying formatter type, actual: %T, expected: %T", formatter.delegate, &log.JSONFormatter{})
+
+	assert.Equal(t, time.UTC, formatter.timestampLocation, "Incorrect timestampLocation")
+}
+
+func TestNewFormatterIncorrectType(t *testing.T) {
+	var defaultConfig = testConfig.Sub("json-formatter")
+	var formatterConfig = testConfig.Sub("incorrect-type-formatter")
+
+	var _, err = newFormatterByConfig(&configWithDefaults{formatterConfig, defaultConfig})
+
+	assert.NotNil(t, err)
+	assert.Equal(t, errors.New("Unexpected formatter type: UNKNOWN"), err, "Unexpected error message")
+}
+
+func TestNewFormatterIncorrectTimestampTimezone(t *testing.T) {
+	var defaultConfig = testConfig.Sub("json-formatter")
+	var formatterConfig = testConfig.Sub("incorrect-timezone-formatter")
+
+	var _, err = newFormatterByConfig(&configWithDefaults{formatterConfig, defaultConfig})
+
+	assert.NotNil(t, err)
+}
+
+type underlyingFormatterMock struct {
+}
+
+func (f *underlyingFormatterMock) Format(entry *log.Entry) ([]byte, error) {
+	var buffer *bytes.Buffer = &bytes.Buffer{}
+	if _, err := buffer.WriteString(entry.Time.Format(time.RFC3339)); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func TestTimezoneFormatter(t *testing.T) {
+	var clockMock clockwork.FakeClock
+	if japanTimezone, err := time.LoadLocation("Asia/Tokyo"); err == nil {
+		clockMock = clockwork.NewFakeClockAt(time.Date(1980, time.August, 3, 13, 0, 0, 0, japanTimezone))
+	} else {
+		t.Fatal("Cannot not get Japan timezone", err)
+	}
+	var formatter = timezoneFormatter{&underlyingFormatterMock{}, time.UTC}
+	var timestamp = clockMock.Now()
+
+	var formattedTimestamp, err = formatter.Format(&log.Entry{Time: timestamp})
+
+	assert.Nil(t, err)
+	assert.Equal(t, timestamp.In(time.UTC).Format(time.RFC3339), string(formattedTimestamp))
+}
+
+func TestNewFormatterDefault(t *testing.T) {
+	var defaultConfig = testConfig.Sub("json-formatter")
+
+	var formatter, err = newFormatterByConfig(&configWithDefaults{nil, defaultConfig})
+
+	assert.Nil(t, err)
+	_, isFormatterDelegate := formatter.delegate.(*log.JSONFormatter)
+	assert.True(t, isFormatterDelegate, "Unexpected underlying formatter type, actual: %T, expected: %T", formatter.delegate, &log.JSONFormatter{})
+
+	assert.Equal(t, time.UTC, formatter.timestampLocation, "Incorrect timestampLocation")
+}
+
+func TestNewOutputFile(t *testing.T) {
+	var outputConfig = testConfig.Sub("file-output")
+
+	var writer, err = newOutputByConfig(&configWithDefaults{outputConfig, viper.New()})
+
+	assert.Nil(t, err)
+	_, isFileWriter := writer.(*rotatelogs.RotateLogs)
+	assert.True(t, isFileWriter, "Unexpected writer type, actual: %T, expected: %T", writer, &rotatelogs.RotateLogs{})
+}
+
+func TestNewOutputStdout(t *testing.T) {
+	var outputConfig = testConfig.Sub("stdout-output")
+
+	var writer, err = newOutputByConfig(&configWithDefaults{outputConfig, viper.New()})
+
+	assert.Nil(t, err)
+	assert.Equal(t, os.Stdout, writer, "Unexpected writer type")
+}
+
+func TestNewOutputIncorrectType(t *testing.T) {
+	var defaultConfig = testConfig.Sub("file-output")
+	var outputConfig = testConfig.Sub("incorrect-type-output")
+
+	var _, err = newOutputByConfig(&configWithDefaults{outputConfig, defaultConfig})
+
+	assert.NotNil(t, err)
+	assert.Equal(t, errors.New("Unexpected output type: UNKNOWN"), err, "Unexpected error message")
+}
+
+func TestNewOutputIncorrectClockTimezone(t *testing.T) {
+	var defaultConfig = testConfig.Sub("file-output")
+	var outputConfig = testConfig.Sub("incorrect-timezone-output")
+
+	var _, err = newOutputByConfig(&configWithDefaults{outputConfig, defaultConfig})
+
+	assert.NotNil(t, err)
+}
+
+func TestNewIncorrectFileOutputFilePattern(t *testing.T) {
+	var defaultConfig = testConfig.Sub("file-output")
+	var outputConfig = testConfig.Sub("incorrect-file-pattern-output")
+
+	var _, err = newOutputByConfig(&configWithDefaults{outputConfig, defaultConfig})
+
+	assert.NotNil(t, err)
+}
+
+func TestNewOutputDefault(t *testing.T) {
+	var defaultConfig = testConfig.Sub("file-output")
+
+	var writer, err = newOutputByConfig(&configWithDefaults{nil, defaultConfig})
+
+	assert.Nil(t, err)
+	_, isFileWriter := writer.(*rotatelogs.RotateLogs)
+	assert.True(t, isFileWriter, "Unexpected writer type, actual: %T, expected: %T", writer, &rotatelogs.RotateLogs{})
+}
+
+func TestInitLogger(t *testing.T) {
+	var loggerConfig = testConfig.Sub("log")
+
+	var err = InitLogger(loggerConfig, viper.New())
+
+	assert.Nil(t, err)
+}
+
+func TestInitLoggerIncorrectLevel(t *testing.T) {
+	var defaultConfig = testConfig.Sub("log")
+	var loggerConfig = testConfig.Sub("incorrect-level-log")
+
+	var err = InitLogger(loggerConfig, defaultConfig)
+
+	assert.Equal(t, errors.New("Unable parse log level string: UNKNOWN, err: not a valid logrus Level: \"UNKNOWN\""), err, "Unexpected error message message")
+}
+
+func TestInitLoggerIncorrectFormatter(t *testing.T) {
+	var defaultConfig = testConfig.Sub("log")
+	var loggerConfig = testConfig.Sub("incorrect-formatter-log")
+
+	var err = InitLogger(loggerConfig, defaultConfig)
+
+	assert.Equal(t, errors.New("Unable initialize log formatter, error: Unexpected formatter type: UNKNOWN"), err, "Unexpected error message")
+}
+
+func TestInitLoggerIncorrectOutput(t *testing.T) {
+	var defaultConfig = testConfig.Sub("log")
+	var loggerConfig = testConfig.Sub("incorrect-output-log")
+
+	var err = InitLogger(loggerConfig, defaultConfig)
+
+	assert.Equal(t, errors.New("Unable initialize log output, error: Unexpected output type: UNKNOWN"), err, "Unexpected error message")
+}

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -78,7 +78,16 @@ func isFileExist(fileName string) bool {
 }
 
 func initLogger() {
-	log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
+	var err error
+	var logLevel log.Level
+	var settings = config.GetString(config.LogLevelKey)
+
+	logLevel, err = log.ParseLevel(settings)
+	if err != nil {
+		log.WithError(err).WithField("settings", settings).Fatal("Cannot parse log level value from settings")
+	}
+
+	log.SetLevel(logLevel)
 }
 
 type daemon struct {

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -38,7 +38,8 @@ var ServeCmd = &cobra.Command{
 		var err error
 
 		loadConfigFileFromCommandLine(cmd.Flags().Lookup("config"))
-		err = logger.InitLogger()
+
+		err = logger.InitLogger(config.Vip().Sub(config.LogKey), config.Defaults().Sub(config.LogKey))
 		if err != nil {
 			log.WithError(err).Fatal("Unable to initialize logger")
 		}

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -38,7 +38,10 @@ var ServeCmd = &cobra.Command{
 		var err error
 
 		loadConfigFileFromCommandLine(cmd.Flags().Lookup("config"))
-		logger.InitLogger()
+		err = logger.InitLogger()
+		if err != nil {
+			log.WithError(err).Fatal("Unable to initialize logger")
+		}
 
 		var d daemon
 		d, err = newDaemon()

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -18,6 +18,7 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	"github.com/singnet/snet-daemon/db"
 	"github.com/singnet/snet-daemon/handler"
+	"github.com/singnet/snet-daemon/logger"
 	log "github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ var ServeCmd = &cobra.Command{
 		var err error
 
 		loadConfigFileFromCommandLine(cmd.Flags().Lookup("config"))
-		initLogger()
+		logger.InitLogger()
 
 		var d daemon
 		d, err = newDaemon()
@@ -75,19 +76,6 @@ func loadConfigFileFromCommandLine(configFlag *pflag.Flag) {
 func isFileExist(fileName string) bool {
 	_, err := os.Stat(fileName)
 	return !os.IsNotExist(err)
-}
-
-func initLogger() {
-	var err error
-	var logLevel log.Level
-	var settings = config.GetString(config.LogLevelKey)
-
-	logLevel, err = log.ParseLevel(settings)
-	if err != nil {
-		log.WithError(err).WithField("settings", settings).Fatal("Cannot parse log level value from settings")
-	}
-
-	log.SetLevel(logLevel)
 }
 
 type daemon struct {


### PR DESCRIPTION
Work on issue https://github.com/singnet/snet-daemon/issues/27.

What is done:
- add default configuration for the snet-daemon including logger configuration
- add logger module with InitLogger function to parse the configuration and initialize logger
- add wrapper for logger formatter to format logger timestamps using configured timezone
- add file writer which supports log rotation
- add unit tests for the logger initialization subsystem

What is not done:
- documentation for the logger configuration