### PR TITLE
Modify ./scripts/test to run all of unit tests

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -10,5 +10,5 @@ pushd $PARENT_PATH
 ./scripts/lint
 
 # Run integration tests
-GOCACHE=off go test -v ./resources/test/
+GOCACHE=off go test -v ./...
 popd


### PR DESCRIPTION
Use ```go test ./...``` command to run all of unit tests not only ```resources/test```.

```
$ go test ./...
?   	github.com/singnet/snet-daemon/blockchain	[no test files]
?   	github.com/singnet/snet-daemon/codec	[no test files]
?   	github.com/singnet/snet-daemon/config	[no test files]
?   	github.com/singnet/snet-daemon/db	[no test files]
?   	github.com/singnet/snet-daemon/handler	[no test files]
?   	github.com/singnet/snet-daemon/resources/installBlockchainDependencies	[no test files]
ok  	github.com/singnet/snet-daemon/resources/test	41.306s
?   	github.com/singnet/snet-daemon/resources/test/echoservice	[no test files]
ok  	github.com/singnet/snet-daemon/snetd	0.021s
?   	github.com/singnet/snet-daemon/snetd/cmd	[no test files]
```