### PR TITLE
More elegant solution for viper subs with defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,6 @@ const (
 )
 
 var vip *viper.Viper
-var defaults *viper.Viper
 
 func init() {
 	var err error
@@ -80,12 +79,12 @@ func init() {
 	vip.SetEnvPrefix("SNET")
 	vip.AutomaticEnv()
 
-	defaults = viper.New()
+	var defaults = viper.New()
 	err = ReadConfigFromJsonString(defaults, defaultConfigJson)
 	if err != nil {
 		panic(fmt.Sprintf("Cannot load default config: %v", err))
 	}
-	setDefaultsFromConfig(vip, defaults)
+	SetDefaultFromConfig(vip, defaults)
 
 	vip.AddConfigPath(".")
 }
@@ -97,18 +96,16 @@ func ReadConfigFromJsonString(config *viper.Viper, json string) error {
 	return config.ReadConfig(strings.NewReader(json))
 }
 
-func setDefaultsFromConfig(config *viper.Viper, defaults *viper.Viper) {
+// SetDefaultFromConfig sets all settings from defaults as default values to
+// the config.
+func SetDefaultFromConfig(config *viper.Viper, defaults *viper.Viper) {
 	for key, value := range defaults.AllSettings() {
-		vip.SetDefault(key, value)
+		config.SetDefault(key, value)
 	}
 }
 
 func Vip() *viper.Viper {
 	return vip
-}
-
-func Defaults() *viper.Viper {
-	return defaults
 }
 
 func Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -178,7 +178,7 @@ func GetBool(key string) bool {
 // function. This is workaround for the issue
 // https://github.com/spf13/viper/issues/559
 func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
-	var allSettingsByKey, ok = config.AllSettings()[key]
+	var allSettingsByKey, ok = config.AllSettings()[strings.ToLower(key)]
 	if !ok {
 		return nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
 
@@ -173,4 +174,23 @@ func GetDuration(key string) time.Duration {
 
 func GetBool(key string) bool {
 	return vip.GetBool(key)
+}
+
+// SubWithDefault returns sub-config by keys including configuration defaults
+// values. It returns nil if no such key. It is analog of the viper.Sub()
+// function. This is workaround for the issue
+// https://github.com/spf13/viper/issues/559
+func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
+	var allSettingsByKey, ok = config.AllSettings()[key]
+	if !ok {
+		return nil
+	}
+
+	var subMap = cast.ToStringMap(allSettingsByKey)
+	var sub = viper.New()
+	for subKey, value := range subMap {
+		sub.Set(subKey, value)
+	}
+
+	return sub
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,3 +43,24 @@ func TestCustomSubNoKey(t *testing.T) {
 
 	assert.Nil(t, sub)
 }
+
+func TestReadConfigFromJsonString(t *testing.T) {
+	var config = viper.New()
+	var jsonConfig = `
+{
+  "object": {
+  	  "field": "value"
+  },
+  "array": [ "item-1", "item-2" ],
+  "string-key": "string-value",
+  "int-key": 42
+}`
+
+	ReadConfigFromJsonString(config, jsonConfig)
+
+	assert.Equal(t, map[string]interface{}{"field": "value"}, config.Get("object"))
+	assert.Equal(t, "value", config.Get("object.field"))
+	assert.Equal(t, []interface{}{"item-1", "item-2"}, config.Get("array"))
+	assert.Equal(t, "string-value", config.Get("string-key"))
+	assert.Equal(t, 42, config.GetInt("int-key"))
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,9 +44,7 @@ func TestCustomSubNoKey(t *testing.T) {
 	assert.Nil(t, sub)
 }
 
-func TestReadConfigFromJsonString(t *testing.T) {
-	var config = viper.New()
-	var jsonConfig = `
+const jsonConfigString = `
 {
   "object": {
   	  "field": "value"
@@ -56,11 +54,28 @@ func TestReadConfigFromJsonString(t *testing.T) {
   "int-key": 42
 }`
 
-	ReadConfigFromJsonString(config, jsonConfig)
-
+func assertConfigIsEqualToJsonConfigString(t *testing.T, config *viper.Viper) {
 	assert.Equal(t, map[string]interface{}{"field": "value"}, config.Get("object"))
 	assert.Equal(t, "value", config.Get("object.field"))
 	assert.Equal(t, []interface{}{"item-1", "item-2"}, config.Get("array"))
 	assert.Equal(t, "string-value", config.Get("string-key"))
 	assert.Equal(t, 42, config.GetInt("int-key"))
+}
+
+func TestReadConfigFromJsonString(t *testing.T) {
+	var config = viper.New()
+
+	ReadConfigFromJsonString(config, jsonConfigString)
+
+	assertConfigIsEqualToJsonConfigString(t, config)
+}
+
+func TestSetDefaultFromConfig(t *testing.T) {
+	var config = viper.New()
+	var defaults = viper.New()
+	ReadConfigFromJsonString(defaults, jsonConfigString)
+
+	SetDefaultFromConfig(config, defaults)
+
+	assertConfigIsEqualToJsonConfigString(t, config)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,6 +44,17 @@ func TestCustomSubNoKey(t *testing.T) {
 	assert.Nil(t, sub)
 }
 
+func TestCustomSubMapWithKeyInOtherCase(t *testing.T) {
+	var config = viper.New()
+	config.Set("outer.INNER", "inner-value")
+	config.SetDefault("OUTER.inner-DEFAULT", "inner-default-value")
+
+	var sub = SubWithDefault(config, "OuTeR")
+
+	assert.Equal(t, "inner-value", sub.Get("iNnEr"))
+	assert.Equal(t, "inner-default-value", sub.Get("iNnEr-DeFaUlT"))
+}
+
 const jsonConfigString = `
 {
   "object": {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCustomSubMap(t *testing.T) {
+	var config = viper.New()
+	config.Set("outer.inner", "inner-value")
+	config.SetDefault("outer.inner-default", "inner-default-value")
+
+	var sub = SubWithDefault(config, "outer")
+
+	assert.Equal(t, "inner-value", sub.Get("inner"))
+	assert.Equal(t, "inner-default-value", sub.Get("inner-default"))
+}
+
+func TestCustomSubSingleValue(t *testing.T) {
+	var config = viper.New()
+	config.SetDefault("outer.inner-default", "inner-default-value")
+
+	var sub = SubWithDefault(config, "outer")
+
+	assert.Equal(t, "inner-default-value", sub.Get("inner-default"))
+}
+
+func TestCustomSubNoValue(t *testing.T) {
+	var config = viper.New()
+	config.SetDefault("outer", "inner-default")
+
+	var sub = SubWithDefault(config, "outer")
+
+	assert.NotNil(t, sub)
+	assert.Equal(t, nil, sub.Get("inner-default"))
+}
+
+func TestCustomSubNoKey(t *testing.T) {
+	var config = viper.New()
+
+	var sub = SubWithDefault(config, "unknown")
+
+	assert.Nil(t, sub)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -136,7 +136,7 @@ func removeLogFiles() {
 func TestNewFormatterTextType(t *testing.T) {
 	var formatterConfig = testConfig.Sub("text-formatter")
 
-	var formatter, err = newFormatterByConfig(&configWithDefaults{formatterConfig, viper.New()})
+	var formatter, err = newFormatterByConfig(formatterConfig)
 
 	assert.Nil(t, err)
 	_, isFormatterDelegate := formatter.delegate.(*log.TextFormatter)
@@ -147,7 +147,7 @@ func TestNewFormatterTextType(t *testing.T) {
 func TestNewFormatterJsonType(t *testing.T) {
 	var formatterConfig = testConfig.Sub("json-formatter")
 
-	var formatter, err = newFormatterByConfig(&configWithDefaults{formatterConfig, viper.New()})
+	var formatter, err = newFormatterByConfig(formatterConfig)
 
 	assert.Nil(t, err)
 	_, isFormatterDelegate := formatter.delegate.(*log.JSONFormatter)
@@ -157,20 +157,20 @@ func TestNewFormatterJsonType(t *testing.T) {
 }
 
 func TestNewFormatterIncorrectType(t *testing.T) {
-	var defaultConfig = testConfig.Sub("json-formatter")
 	var formatterConfig = testConfig.Sub("incorrect-type-formatter")
+	config.SetDefaultFromConfig(formatterConfig, testConfig.Sub("json-formatter"))
 
-	var _, err = newFormatterByConfig(&configWithDefaults{formatterConfig, defaultConfig})
+	var _, err = newFormatterByConfig(formatterConfig)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, errors.New("Unexpected formatter type: UNKNOWN"), err, "Unexpected error message")
 }
 
 func TestNewFormatterIncorrectTimestampTimezone(t *testing.T) {
-	var defaultConfig = testConfig.Sub("json-formatter")
 	var formatterConfig = testConfig.Sub("incorrect-timezone-formatter")
+	config.SetDefaultFromConfig(formatterConfig, testConfig.Sub("json-formatter"))
 
-	var _, err = newFormatterByConfig(&configWithDefaults{formatterConfig, defaultConfig})
+	var _, err = newFormatterByConfig(formatterConfig)
 
 	assert.NotNil(t, err)
 }
@@ -203,9 +203,10 @@ func TestTimezoneFormatter(t *testing.T) {
 }
 
 func TestNewFormatterDefault(t *testing.T) {
-	var defaultConfig = testConfig.Sub("json-formatter")
+	var formatterConfig = viper.New()
+	config.SetDefaultFromConfig(formatterConfig, testConfig.Sub("json-formatter"))
 
-	var formatter, err = newFormatterByConfig(&configWithDefaults{nil, defaultConfig})
+	var formatter, err = newFormatterByConfig(formatterConfig)
 
 	assert.Nil(t, err)
 	_, isFormatterDelegate := formatter.delegate.(*log.JSONFormatter)
@@ -217,7 +218,7 @@ func TestNewFormatterDefault(t *testing.T) {
 func TestNewOutputFile(t *testing.T) {
 	var outputConfig = testConfig.Sub("file-output")
 
-	var writer, err = newOutputByConfig(&configWithDefaults{outputConfig, viper.New()})
+	var writer, err = newOutputByConfig(outputConfig)
 
 	assert.Nil(t, err)
 	_, isFileWriter := writer.(*rotatelogs.RotateLogs)
@@ -227,44 +228,45 @@ func TestNewOutputFile(t *testing.T) {
 func TestNewOutputStdout(t *testing.T) {
 	var outputConfig = testConfig.Sub("stdout-output")
 
-	var writer, err = newOutputByConfig(&configWithDefaults{outputConfig, viper.New()})
+	var writer, err = newOutputByConfig(outputConfig)
 
 	assert.Nil(t, err)
 	assert.Equal(t, os.Stdout, writer, "Unexpected writer type")
 }
 
 func TestNewOutputIncorrectType(t *testing.T) {
-	var defaultConfig = testConfig.Sub("file-output")
 	var outputConfig = testConfig.Sub("incorrect-type-output")
+	config.SetDefaultFromConfig(outputConfig, testConfig.Sub("file-output"))
 
-	var _, err = newOutputByConfig(&configWithDefaults{outputConfig, defaultConfig})
+	var _, err = newOutputByConfig(outputConfig)
 
 	assert.NotNil(t, err)
 	assert.Equal(t, errors.New("Unexpected output type: UNKNOWN"), err, "Unexpected error message")
 }
 
 func TestNewOutputIncorrectClockTimezone(t *testing.T) {
-	var defaultConfig = testConfig.Sub("file-output")
 	var outputConfig = testConfig.Sub("incorrect-timezone-output")
+	config.SetDefaultFromConfig(outputConfig, testConfig.Sub("file-output"))
 
-	var _, err = newOutputByConfig(&configWithDefaults{outputConfig, defaultConfig})
+	var _, err = newOutputByConfig(outputConfig)
 
 	assert.NotNil(t, err)
 }
 
 func TestNewIncorrectFileOutputFilePattern(t *testing.T) {
-	var defaultConfig = testConfig.Sub("file-output")
 	var outputConfig = testConfig.Sub("incorrect-file-pattern-output")
+	config.SetDefaultFromConfig(outputConfig, testConfig.Sub("file-output"))
 
-	var _, err = newOutputByConfig(&configWithDefaults{outputConfig, defaultConfig})
+	var _, err = newOutputByConfig(outputConfig)
 
 	assert.NotNil(t, err)
 }
 
 func TestNewOutputDefault(t *testing.T) {
-	var defaultConfig = testConfig.Sub("file-output")
+	var outputConfig = viper.New()
+	config.SetDefaultFromConfig(outputConfig, testConfig.Sub("file-output"))
 
-	var writer, err = newOutputByConfig(&configWithDefaults{nil, defaultConfig})
+	var writer, err = newOutputByConfig(outputConfig)
 
 	assert.Nil(t, err)
 	_, isFileWriter := writer.(*rotatelogs.RotateLogs)
@@ -274,34 +276,34 @@ func TestNewOutputDefault(t *testing.T) {
 func TestInitLogger(t *testing.T) {
 	var loggerConfig = testConfig.Sub("log")
 
-	var err = InitLogger(loggerConfig, viper.New())
+	var err = InitLogger(loggerConfig)
 
 	assert.Nil(t, err)
 }
 
 func TestInitLoggerIncorrectLevel(t *testing.T) {
-	var defaultConfig = testConfig.Sub("log")
 	var loggerConfig = testConfig.Sub("incorrect-level-log")
+	config.SetDefaultFromConfig(loggerConfig, testConfig.Sub("log"))
 
-	var err = InitLogger(loggerConfig, defaultConfig)
+	var err = InitLogger(loggerConfig)
 
 	assert.Equal(t, errors.New("Unable parse log level string: UNKNOWN, err: not a valid logrus Level: \"UNKNOWN\""), err, "Unexpected error message message")
 }
 
 func TestInitLoggerIncorrectFormatter(t *testing.T) {
-	var defaultConfig = testConfig.Sub("log")
 	var loggerConfig = testConfig.Sub("incorrect-formatter-log")
+	config.SetDefaultFromConfig(loggerConfig, testConfig.Sub("log"))
 
-	var err = InitLogger(loggerConfig, defaultConfig)
+	var err = InitLogger(loggerConfig)
 
 	assert.Equal(t, errors.New("Unable initialize log formatter, error: Unexpected formatter type: UNKNOWN"), err, "Unexpected error message")
 }
 
 func TestInitLoggerIncorrectOutput(t *testing.T) {
-	var defaultConfig = testConfig.Sub("log")
 	var loggerConfig = testConfig.Sub("incorrect-output-log")
+	config.SetDefaultFromConfig(loggerConfig, testConfig.Sub("log"))
 
-	var err = InitLogger(loggerConfig, defaultConfig)
+	var err = InitLogger(loggerConfig)
 
 	assert.Equal(t, errors.New("Unable initialize log output, error: Unexpected output type: UNKNOWN"), err, "Unexpected error message")
 }

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -39,7 +39,7 @@ var ServeCmd = &cobra.Command{
 
 		loadConfigFileFromCommandLine(cmd.Flags().Lookup("config"))
 
-		err = logger.InitLogger(config.Vip().Sub(config.LogKey), config.Defaults().Sub(config.LogKey))
+		err = logger.InitLogger(config.SubWithDefault(config.Vip(), config.LogKey))
 		if err != nil {
 			log.WithError(err).Fatal("Unable to initialize logger")
 		}


### PR DESCRIPTION
Implement SubWithDefault method to replace viper.Sub(). viper.Sub() suffers from issue https://github.com/spf13/viper/issues/559. SubWithDefault method workarounds issue by adding default values to the sub configuration returned.

Fix logger initialization code accordingly. Add unit tests for new methods and fix old unit tests.