### PR TITLE
Add gRPC interceptor stub to check gRPC escrow contract payment channel state

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -27,14 +27,28 @@ const (
 	jobPendingState = "PENDING"
 	jobFundedState  = "FUNDED"
 
-	// PaymentTypeHeader is a name of the field which specifies type of payment
-	// used to pay for a RPC call. Types supported "job", "escrow".
-	PaymentTypeHeader  = "snet-payment-type"
+	// PaymentTypeHeader is a type of payment used to pay for a RPC call.
+	// Supported types are: "job", "escrow".
+	PaymentTypeHeader = "snet-payment-type"
+	// JobPaymentType each call should be payed using unique instance of funded Job
+	JobPaymentType = "job"
+	// EscrowPaymentType each call should have id and nonce of payment channel
+	// in metadata.
+	EscrowPaymentType = "escrow"
+
 	JobAddressHeader   = "snet-job-address"
 	JobSignatureHeader = "snet-job-signature"
 
-	JobPaymentType    = "job"
-	EscrowPaymentType = "escrow"
+	// PaymentChannelIdHeader is a MultiPartyEscrow contract payment channel id
+	PaymentChannelIdHeader = "snet-payment-channel-id"
+	// PaymentChannelNonceHeader is a payment channel nonce value
+	PaymentChannelNonceHeader = "snet-payment-channel-nonce"
+	// PaymentChannelAmountHeader is an amount of payment channel value
+	// which server is authorized withdraw after handling the RPC call.
+	PaymentChannelAmountHeader = "snet-payment-channel-amount"
+	// PaymentChannelSignatureHeader is a signature of the client to confirm
+	// authorized amount
+	PaymentChannelSignatureHeader = "snet-payment-channel-signature"
 )
 
 var (

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -8,47 +8,16 @@ import (
 	"crypto/ecdsa"
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/json"
 
 	"github.com/coreos/bbolt"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
 	"github.com/singnet/snet-daemon/config"
-	"github.com/singnet/snet-daemon/db"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-)
-
-const (
-	jobPendingState = "PENDING"
-	jobFundedState  = "FUNDED"
-
-	// PaymentTypeHeader is a type of payment used to pay for a RPC call.
-	// Supported types are: "job", "escrow".
-	PaymentTypeHeader = "snet-payment-type"
-	// JobPaymentType each call should be payed using unique instance of funded Job
-	JobPaymentType = "job"
-	// EscrowPaymentType each call should have id and nonce of payment channel
-	// in metadata.
-	EscrowPaymentType = "escrow"
-
-	JobAddressHeader   = "snet-job-address"
-	JobSignatureHeader = "snet-job-signature"
-
-	// PaymentChannelIdHeader is a MultiPartyEscrow contract payment channel id
-	PaymentChannelIdHeader = "snet-payment-channel-id"
-	// PaymentChannelNonceHeader is a payment channel nonce value
-	PaymentChannelNonceHeader = "snet-payment-channel-nonce"
-	// PaymentChannelAmountHeader is an amount of payment channel value
-	// which server is authorized withdraw after handling the RPC call.
-	PaymentChannelAmountHeader = "snet-payment-channel-amount"
-	// PaymentChannelSignatureHeader is a signature of the client to confirm
-	// authorized amount
-	PaymentChannelSignatureHeader = "snet-payment-channel-signature"
 )
 
 var (
@@ -150,95 +119,4 @@ func (p Processor) GrpcStreamInterceptor() grpc.StreamServerInterceptor {
 	}
 
 	return noOpInterceptor
-}
-
-func (p Processor) IsValidJobInvocation(jobAddressBytes, jobSignatureBytes []byte) bool {
-	log := log.WithFields(log.Fields{
-		"jobAddress":   common.BytesToAddress(jobAddressBytes).Hex(),
-		"jobSignature": hex.EncodeToString(jobSignatureBytes)})
-
-	// Get job state from db
-	log.Debug("retrieving job from database")
-	job := &db.Job{}
-
-	p.boltDB.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(db.JobBucketName)
-		jobBytes := bucket.Get(jobAddressBytes)
-		if jobBytes != nil {
-			json.Unmarshal(jobBytes, job)
-		}
-		return nil
-	})
-
-	// If job is marked completed locally, reject
-	if job.Completed {
-		log.Debug("job already marked completed locally")
-		return false
-	}
-
-	v, r, s, err := parseSignature(jobSignatureBytes)
-	if err != nil {
-		log.WithError(err).Error("error parsing signature")
-		return false
-	}
-
-	pubKey, err := crypto.SigToPub(p.sigHasher(jobAddressBytes), bytes.Join([][]byte{jobSignatureBytes[0:64], {v % 27}},
-		[]byte{}))
-	if err != nil {
-		log.WithError(err).Error("error recovering signature")
-		return false
-	}
-
-	// If job is FUNDED and signature validates, skip on-chain validation
-	if job.JobState == jobFundedState && bytes.Equal(crypto.PubkeyToAddress(*pubKey).Bytes(), job.Consumer) {
-		log.Debug("validated job invocation locally")
-		return true
-	}
-
-	log.Debug("unable to validate job invocation locally; falling back to on-chain validation")
-
-	// Fall back to on-chain validation
-	if validated, err := p.agent.ValidateJobInvocation(&bind.CallOpts{
-		Pending: true,
-		From:    common.HexToAddress(p.address)}, common.BytesToAddress(jobAddressBytes), v, r, s); err != nil {
-		log.WithError(err).Error("error validating job on chain")
-		return false
-	} else if !validated {
-		log.Debug("job failed to validate")
-		return false
-	}
-
-	log.Debug("validated job invocation on chain")
-	return true
-}
-
-func (p Processor) CompleteJob(jobAddressBytes, jobSignatureBytes []byte) {
-	job := &db.Job{}
-
-	// Mark the job completed in the db synchronously
-	if err := p.boltDB.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(db.JobBucketName)
-		jobBytes := bucket.Get(jobAddressBytes)
-		if jobBytes != nil {
-			json.Unmarshal(jobBytes, job)
-		}
-		job.Completed = true
-		job.JobSignature = jobSignatureBytes
-		jobBytes, err := json.Marshal(job)
-		if err != nil {
-			return err
-		}
-		if err = bucket.Put(jobAddressBytes, jobBytes); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		log.WithFields(log.Fields{
-			"jobAddress":   common.BytesToAddress(jobAddressBytes).Hex(),
-			"jobSignature": hex.EncodeToString(jobSignatureBytes),
-		}).WithError(err).Error("error marking job completed in db")
-	}
-
-	// Submit the job for completion
-	p.jobCompletionQueue <- &jobInfo{jobAddressBytes, jobSignatureBytes}
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -24,10 +24,17 @@ import (
 )
 
 const (
-	jobPendingState    = "PENDING"
-	jobFundedState     = "FUNDED"
+	jobPendingState = "PENDING"
+	jobFundedState  = "FUNDED"
+
+	// PaymentTypeHeader is a name of the field which specifies type of payment
+	// used to pay for a RPC call. Types supported "job", "escrow".
+	PaymentTypeHeader  = "snet-payment-type"
 	JobAddressHeader   = "snet-job-address"
 	JobSignatureHeader = "snet-job-signature"
+
+	JobPaymentType    = "job"
+	EscrowPaymentType = "escrow"
 )
 
 var (

--- a/blockchain/escrow.go
+++ b/blockchain/escrow.go
@@ -1,0 +1,58 @@
+package blockchain
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"math/big"
+)
+
+type PaymentChannelKey struct {
+	Id    *big.Int
+	Nonce *big.Int
+}
+
+type PaymentChannelState struct {
+	FullAmount       *big.Int
+	AuthorizedAmount *big.Int
+	PaymentSignature []byte
+}
+
+type PaymentChannelStorage interface {
+	Get(key *PaymentChannelKey) *PaymentChannelState
+	CompareAndSwap(key *PaymentChannelKey, prevState *PaymentChannelState, newState *PaymentChannelState) error
+}
+
+// escrowPaymentHandler implements paymentHandlerType interface
+type escrowPaymentHandler struct {
+	md      metadata.MD
+	storage PaymentChannelStorage
+}
+
+func newEscrowPaymentHandler() *escrowPaymentHandler {
+	return &escrowPaymentHandler{}
+}
+
+func (h *escrowPaymentHandler) validatePayment() error {
+	/*
+		id, err := getBigInt(h.md, PaymentChannelIdHeader)
+		if err != nil {
+			return err
+		}
+
+		nonce, err := getBigInt(h.md, PaymentChannelNonceHeader)
+		if err != nil {
+			return err
+		}
+
+		paymentChannelState := h.storage.Get(&PaymentChannelKey{id, nonce})
+
+		signature, err := getBytes(h.md, PaymentChannelSignatureHeader)
+	*/
+
+	return status.Errorf(codes.Unimplemented, "not implemented yet")
+}
+
+func (h *escrowPaymentHandler) completePayment(err error) error {
+	return err
+}

--- a/blockchain/escrow.go
+++ b/blockchain/escrow.go
@@ -68,6 +68,8 @@ func (h *escrowPaymentHandler) validatePayment() error {
 	return status.Errorf(codes.Unimplemented, "not implemented yet")
 }
 
-func (h *escrowPaymentHandler) completePayment(err error) error {
-	return err
+func (h *escrowPaymentHandler) completePayment() {
+}
+
+func (h *escrowPaymentHandler) completePaymentAfterError(err error) {
 }

--- a/blockchain/escrow.go
+++ b/blockchain/escrow.go
@@ -8,6 +8,19 @@ import (
 	"time"
 )
 
+const (
+	// PaymentChannelIdHeader is a MultiPartyEscrow contract payment channel id
+	PaymentChannelIdHeader = "snet-payment-channel-id"
+	// PaymentChannelNonceHeader is a payment channel nonce value
+	PaymentChannelNonceHeader = "snet-payment-channel-nonce"
+	// PaymentChannelAmountHeader is an amount of payment channel value
+	// which server is authorized withdraw after handling the RPC call.
+	PaymentChannelAmountHeader = "snet-payment-channel-amount"
+	// PaymentChannelSignatureHeader is a signature of the client to confirm
+	// authorized amount
+	PaymentChannelSignatureHeader = "snet-payment-channel-signature"
+)
+
 type PaymentChannelKey struct {
 	Id    *big.Int
 	Nonce *big.Int

--- a/blockchain/escrow.go
+++ b/blockchain/escrow.go
@@ -5,6 +5,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"math/big"
+	"time"
 )
 
 type PaymentChannelKey struct {
@@ -13,9 +14,10 @@ type PaymentChannelKey struct {
 }
 
 type PaymentChannelState struct {
-	FullAmount       *big.Int
-	AuthorizedAmount *big.Int
-	PaymentSignature []byte
+	FullAmount         *big.Int
+	ExpirationDateTime time.Time
+	AuthorizedAmount   *big.Int
+	PaymentSignature   []byte
 }
 
 type PaymentChannelStorage interface {

--- a/blockchain/interceptors.go
+++ b/blockchain/interceptors.go
@@ -55,51 +55,6 @@ type paymentHandlerType interface {
 	completePayment(error) error
 }
 
-type jobPaymentHandler struct {
-	p                 Processor
-	md                metadata.MD
-	jobAddressBytes   []byte
-	jobSignatureBytes []byte
-}
-
-func newJobPaymentHandler(p Processor, md metadata.MD) *jobPaymentHandler {
-	return &jobPaymentHandler{p: p, md: md}
-}
-
-func (h *jobPaymentHandler) validatePayment() error {
-	jobAddressMd, ok := h.md[JobAddressHeader]
-	if !ok {
-		return status.Errorf(codes.InvalidArgument, "missing snet-job-address")
-	}
-
-	h.jobAddressBytes = common.FromHex(jobAddressMd[0])
-
-	jobSignatureMd, ok := h.md[JobSignatureHeader]
-	if !ok {
-		return status.Errorf(codes.InvalidArgument, "missing snet-job-signature")
-	}
-
-	h.jobSignatureBytes = common.FromHex(jobSignatureMd[0])
-	valid := h.p.IsValidJobInvocation(h.jobAddressBytes, h.jobSignatureBytes)
-	if !valid {
-		return status.Errorf(codes.Unauthenticated, "job invocation not valid")
-	}
-
-	return nil
-}
-
-func (h *jobPaymentHandler) completePayment(err error) error {
-	if err == nil {
-		h.p.CompleteJob(h.jobAddressBytes, h.jobSignatureBytes)
-	}
-	return err
-}
-
-func noOpInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,
-	handler grpc.StreamHandler) error {
-	return handler(srv, ss)
-}
-
 func getBigInt(md metadata.MD, key string) (*big.Int, error) {
 	array := md.Get(key)
 	if len(array) == 0 {
@@ -121,4 +76,9 @@ func getBytes(md metadata.MD, key string) ([]byte, error) {
 		return nil, status.Errorf(codes.InvalidArgument, "missing \"%v\"", key)
 	}
 	return common.FromHex(value[0]), nil
+}
+
+func noOpInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler) error {
+	return handler(srv, ss)
 }

--- a/blockchain/interceptors.go
+++ b/blockchain/interceptors.go
@@ -9,6 +9,17 @@ import (
 	"math/big"
 )
 
+const (
+	// PaymentTypeHeader is a type of payment used to pay for a RPC call.
+	// Supported types are: "job", "escrow".
+	PaymentTypeHeader = "snet-payment-type"
+	// JobPaymentType each call should be payed using unique instance of funded Job
+	JobPaymentType = "job"
+	// EscrowPaymentType each call should have id and nonce of payment channel
+	// in metadata.
+	EscrowPaymentType = "escrow"
+)
+
 func (p Processor) jobValidationInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler) error {
 

--- a/blockchain/interceptors.go
+++ b/blockchain/interceptors.go
@@ -39,8 +39,13 @@ func (p Processor) jobValidationInterceptor(srv interface{}, ss grpc.ServerStrea
 	}
 
 	err = handler(srv, ss)
+	if err != nil {
+		paymentHandler.completePaymentAfterError(err)
+		return err
+	}
 
-	return paymentHandler.completePayment(err)
+	paymentHandler.completePayment()
+	return nil
 }
 
 func (p Processor) newPaymentHandlerByType(md metadata.MD) (paymentHandlerType, error) {
@@ -63,7 +68,8 @@ func (p Processor) newPaymentHandlerByType(md metadata.MD) (paymentHandlerType, 
 
 type paymentHandlerType interface {
 	validatePayment() error
-	completePayment(error) error
+	completePayment()
+	completePaymentAfterError(error)
 }
 
 func getBigInt(md metadata.MD, key string) (*big.Int, error) {

--- a/blockchain/interceptors.go
+++ b/blockchain/interceptors.go
@@ -16,29 +16,73 @@ func (p Processor) jobValidationInterceptor(srv interface{}, ss grpc.ServerStrea
 		return status.Errorf(codes.InvalidArgument, "missing metadata")
 	}
 
-	jobAddressMd, ok := md[JobAddressHeader]
-	if !ok {
-		return status.Errorf(codes.InvalidArgument, "missing snet-job-address")
+	paymentTypeMd, ok := md[PaymentTypeHeader]
+	paymentType := ""
+	if ok && len(paymentTypeMd) > 0 {
+		paymentType = paymentTypeMd[0]
 	}
 
-	jobAddressBytes := common.FromHex(jobAddressMd[0])
-
-	jobSignatureMd, ok := md[JobSignatureHeader]
-	if !ok {
-		return status.Errorf(codes.InvalidArgument, "missing snet-job-signature")
+	var paymentHandler paymentHandlerType
+	switch {
+	case !ok || paymentType == JobPaymentType:
+		paymentHandler = newJobPaymentHandler(p, md)
+	default:
+		return status.Errorf(codes.InvalidArgument, "unexpected \"%v\", value: \"%v\"", PaymentTypeHeader, paymentTypeMd)
 	}
 
-	jobSignatureBytes := common.FromHex(jobSignatureMd[0])
-
-	if p.IsValidJobInvocation(jobAddressBytes, jobSignatureBytes) {
-		err := handler(srv, ss)
-		if err == nil {
-			p.CompleteJob(jobAddressBytes, jobSignatureBytes)
-		}
+	valid, err := paymentHandler.validatePayment()
+	if !valid {
 		return err
 	}
 
-	return status.Errorf(codes.Unauthenticated, "job invocation not valid")
+	err = handler(srv, ss)
+
+	return paymentHandler.completePayment(err)
+}
+
+type paymentHandlerType interface {
+	validatePayment() (bool, error)
+	completePayment(error) error
+}
+
+type jobPaymentHandler struct {
+	p                 Processor
+	md                metadata.MD
+	jobAddressBytes   []byte
+	jobSignatureBytes []byte
+}
+
+func newJobPaymentHandler(p Processor, md metadata.MD) paymentHandlerType {
+	return &jobPaymentHandler{p: p, md: md}
+}
+
+func (h *jobPaymentHandler) validatePayment() (bool, error) {
+	jobAddressMd, ok := h.md[JobAddressHeader]
+	if !ok {
+		return false, status.Errorf(codes.InvalidArgument, "missing snet-job-address")
+	}
+
+	h.jobAddressBytes = common.FromHex(jobAddressMd[0])
+
+	jobSignatureMd, ok := h.md[JobSignatureHeader]
+	if !ok {
+		return false, status.Errorf(codes.InvalidArgument, "missing snet-job-signature")
+	}
+
+	h.jobSignatureBytes = common.FromHex(jobSignatureMd[0])
+	valid := h.p.IsValidJobInvocation(h.jobAddressBytes, h.jobSignatureBytes)
+	if !valid {
+		return false, status.Errorf(codes.Unauthenticated, "job invocation not valid")
+	}
+
+	return true, nil
+}
+
+func (h *jobPaymentHandler) completePayment(err error) error {
+	if err == nil {
+		h.p.CompleteJob(h.jobAddressBytes, h.jobSignatureBytes)
+	}
+	return err
 }
 
 func noOpInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,

--- a/blockchain/interceptors.go
+++ b/blockchain/interceptors.go
@@ -53,7 +53,7 @@ func (p Processor) newPaymentHandlerByType(md metadata.MD) (paymentHandlerType, 
 
 	switch {
 	case paymentType == JobPaymentType:
-		return newJobPaymentHandler(p, md), nil
+		return newJobPaymentHandler(&p, md), nil
 	case paymentType == EscrowPaymentType:
 		return newEscrowPaymentHandler(), nil
 	default:

--- a/blockchain/interceptors_test.go
+++ b/blockchain/interceptors_test.go
@@ -1,0 +1,36 @@
+package blockchain
+
+import (
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"testing"
+)
+
+func TestGetBytes(t *testing.T) {
+	md := metadata.Pairs("test-key", "0xfFfE0100")
+
+	bytes, err := getBytes(md, "test-key")
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{255, 254, 1, 0}, bytes)
+}
+
+func TestGetBytesNoPrefix(t *testing.T) {
+	md := metadata.Pairs("test-key", "fFfE0100")
+
+	bytes, err := getBytes(md, "test-key")
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{255, 254, 1, 0}, bytes)
+}
+
+func TestGetBytesNoValue(t *testing.T) {
+	md := metadata.Pairs("unknown-key", "fFfE0100")
+
+	bytes, err := getBytes(md, "test-key")
+
+	assert.Equal(t, status.Errorf(codes.InvalidArgument, "missing \"test-key\""), err)
+	assert.Nil(t, bytes)
+}

--- a/blockchain/job.go
+++ b/blockchain/job.go
@@ -1,9 +1,26 @@
 package blockchain
 
 import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"github.com/coreos/bbolt"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/singnet/snet-daemon/db"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	jobPendingState = "PENDING"
+	jobFundedState  = "FUNDED"
+
+	JobAddressHeader   = "snet-job-address"
+	JobSignatureHeader = "snet-job-signature"
 )
 
 type jobPaymentHandler struct {
@@ -43,4 +60,95 @@ func (h *jobPaymentHandler) completePayment(err error) error {
 		h.p.CompleteJob(h.jobAddressBytes, h.jobSignatureBytes)
 	}
 	return err
+}
+
+func (p Processor) IsValidJobInvocation(jobAddressBytes, jobSignatureBytes []byte) bool {
+	log := log.WithFields(log.Fields{
+		"jobAddress":   common.BytesToAddress(jobAddressBytes).Hex(),
+		"jobSignature": hex.EncodeToString(jobSignatureBytes)})
+
+	// Get job state from db
+	log.Debug("retrieving job from database")
+	job := &db.Job{}
+
+	p.boltDB.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(db.JobBucketName)
+		jobBytes := bucket.Get(jobAddressBytes)
+		if jobBytes != nil {
+			json.Unmarshal(jobBytes, job)
+		}
+		return nil
+	})
+
+	// If job is marked completed locally, reject
+	if job.Completed {
+		log.Debug("job already marked completed locally")
+		return false
+	}
+
+	v, r, s, err := parseSignature(jobSignatureBytes)
+	if err != nil {
+		log.WithError(err).Error("error parsing signature")
+		return false
+	}
+
+	pubKey, err := crypto.SigToPub(p.sigHasher(jobAddressBytes), bytes.Join([][]byte{jobSignatureBytes[0:64], {v % 27}},
+		[]byte{}))
+	if err != nil {
+		log.WithError(err).Error("error recovering signature")
+		return false
+	}
+
+	// If job is FUNDED and signature validates, skip on-chain validation
+	if job.JobState == jobFundedState && bytes.Equal(crypto.PubkeyToAddress(*pubKey).Bytes(), job.Consumer) {
+		log.Debug("validated job invocation locally")
+		return true
+	}
+
+	log.Debug("unable to validate job invocation locally; falling back to on-chain validation")
+
+	// Fall back to on-chain validation
+	if validated, err := p.agent.ValidateJobInvocation(&bind.CallOpts{
+		Pending: true,
+		From:    common.HexToAddress(p.address)}, common.BytesToAddress(jobAddressBytes), v, r, s); err != nil {
+		log.WithError(err).Error("error validating job on chain")
+		return false
+	} else if !validated {
+		log.Debug("job failed to validate")
+		return false
+	}
+
+	log.Debug("validated job invocation on chain")
+	return true
+}
+
+func (p Processor) CompleteJob(jobAddressBytes, jobSignatureBytes []byte) {
+	job := &db.Job{}
+
+	// Mark the job completed in the db synchronously
+	if err := p.boltDB.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(db.JobBucketName)
+		jobBytes := bucket.Get(jobAddressBytes)
+		if jobBytes != nil {
+			json.Unmarshal(jobBytes, job)
+		}
+		job.Completed = true
+		job.JobSignature = jobSignatureBytes
+		jobBytes, err := json.Marshal(job)
+		if err != nil {
+			return err
+		}
+		if err = bucket.Put(jobAddressBytes, jobBytes); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		log.WithFields(log.Fields{
+			"jobAddress":   common.BytesToAddress(jobAddressBytes).Hex(),
+			"jobSignature": hex.EncodeToString(jobSignatureBytes),
+		}).WithError(err).Error("error marking job completed in db")
+	}
+
+	// Submit the job for completion
+	p.jobCompletionQueue <- &jobInfo{jobAddressBytes, jobSignatureBytes}
 }

--- a/blockchain/job.go
+++ b/blockchain/job.go
@@ -24,13 +24,13 @@ const (
 )
 
 type jobPaymentHandler struct {
-	p                 Processor
+	p                 *Processor
 	md                metadata.MD
 	jobAddressBytes   []byte
 	jobSignatureBytes []byte
 }
 
-func newJobPaymentHandler(p Processor, md metadata.MD) *jobPaymentHandler {
+func newJobPaymentHandler(p *Processor, md metadata.MD) *jobPaymentHandler {
 	return &jobPaymentHandler{p: p, md: md}
 }
 
@@ -62,7 +62,7 @@ func (h *jobPaymentHandler) completePayment(err error) error {
 	return err
 }
 
-func (p Processor) IsValidJobInvocation(jobAddressBytes, jobSignatureBytes []byte) bool {
+func (p *Processor) IsValidJobInvocation(jobAddressBytes, jobSignatureBytes []byte) bool {
 	log := log.WithFields(log.Fields{
 		"jobAddress":   common.BytesToAddress(jobAddressBytes).Hex(),
 		"jobSignature": hex.EncodeToString(jobSignatureBytes)})
@@ -122,7 +122,7 @@ func (p Processor) IsValidJobInvocation(jobAddressBytes, jobSignatureBytes []byt
 	return true
 }
 
-func (p Processor) CompleteJob(jobAddressBytes, jobSignatureBytes []byte) {
+func (p *Processor) CompleteJob(jobAddressBytes, jobSignatureBytes []byte) {
 	job := &db.Job{}
 
 	// Mark the job completed in the db synchronously

--- a/blockchain/job.go
+++ b/blockchain/job.go
@@ -1,7 +1,6 @@
 package blockchain
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -19,19 +18,18 @@ func newJobPaymentHandler(p Processor, md metadata.MD) *jobPaymentHandler {
 }
 
 func (h *jobPaymentHandler) validatePayment() error {
-	jobAddressMd, ok := h.md[JobAddressHeader]
-	if !ok {
-		return status.Errorf(codes.InvalidArgument, "missing snet-job-address")
+	var err error
+
+	h.jobAddressBytes, err = getBytes(h.md, JobAddressHeader)
+	if err != nil {
+		return err
 	}
 
-	h.jobAddressBytes = common.FromHex(jobAddressMd[0])
-
-	jobSignatureMd, ok := h.md[JobSignatureHeader]
-	if !ok {
-		return status.Errorf(codes.InvalidArgument, "missing snet-job-signature")
+	h.jobSignatureBytes, err = getBytes(h.md, JobSignatureHeader)
+	if err != nil {
+		return err
 	}
 
-	h.jobSignatureBytes = common.FromHex(jobSignatureMd[0])
 	valid := h.p.IsValidJobInvocation(h.jobAddressBytes, h.jobSignatureBytes)
 	if !valid {
 		return status.Errorf(codes.Unauthenticated, "job invocation not valid")

--- a/blockchain/job.go
+++ b/blockchain/job.go
@@ -55,11 +55,11 @@ func (h *jobPaymentHandler) validatePayment() error {
 	return nil
 }
 
-func (h *jobPaymentHandler) completePayment(err error) error {
-	if err == nil {
-		h.p.CompleteJob(h.jobAddressBytes, h.jobSignatureBytes)
-	}
-	return err
+func (h *jobPaymentHandler) completePayment() {
+	h.p.CompleteJob(h.jobAddressBytes, h.jobSignatureBytes)
+}
+
+func (h *jobPaymentHandler) completePaymentAfterError(err error) {
 }
 
 func (p *Processor) IsValidJobInvocation(jobAddressBytes, jobSignatureBytes []byte) bool {

--- a/blockchain/job.go
+++ b/blockchain/job.go
@@ -1,0 +1,48 @@
+package blockchain
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type jobPaymentHandler struct {
+	p                 Processor
+	md                metadata.MD
+	jobAddressBytes   []byte
+	jobSignatureBytes []byte
+}
+
+func newJobPaymentHandler(p Processor, md metadata.MD) *jobPaymentHandler {
+	return &jobPaymentHandler{p: p, md: md}
+}
+
+func (h *jobPaymentHandler) validatePayment() error {
+	jobAddressMd, ok := h.md[JobAddressHeader]
+	if !ok {
+		return status.Errorf(codes.InvalidArgument, "missing snet-job-address")
+	}
+
+	h.jobAddressBytes = common.FromHex(jobAddressMd[0])
+
+	jobSignatureMd, ok := h.md[JobSignatureHeader]
+	if !ok {
+		return status.Errorf(codes.InvalidArgument, "missing snet-job-signature")
+	}
+
+	h.jobSignatureBytes = common.FromHex(jobSignatureMd[0])
+	valid := h.p.IsValidJobInvocation(h.jobAddressBytes, h.jobSignatureBytes)
+	if !valid {
+		return status.Errorf(codes.Unauthenticated, "job invocation not valid")
+	}
+
+	return nil
+}
+
+func (h *jobPaymentHandler) completePayment(err error) error {
+	if err == nil {
+		h.p.CompleteJob(h.jobAddressBytes, h.jobSignatureBytes)
+	}
+	return err
+}


### PR DESCRIPTION
Start of the work on issue https://github.com/singnet/snet-daemon/issues/31

As we are introducing new way of payment MultiPartyEscrow contract (see https://github.com/singnet/platform-contracts/pull/39) we need to support it in ```snet-daemon```. In order to do this I have modified gRPC interceptor to switch between two different ways of payment:
- job - an old one
- escrow - new way using escrow contract

Proposed API is described at [multiPartyEscrowApiChanges.md#daemon-api-changes](https://github.com/singnet/wiki/blob/master/multiPartyEscrowContract/multiPartyEscrowApiChanges.md#daemon-api-changes) page

What is done:
- move Job verification code to the ```blockchain/job.go```
- move MultiPartyEscrow payment channel verification code to the ```blockchain/escrow.go```
- add factory method in ```blockchain/interceptor.go``` to get either Job or Escrow payment verifier
- specify PaymentChannel storage API which will be used by snet-daemon to validate escrow contract payment channel state

Next steps:
- implement escrow contract payment channel verification logic