### PR TITLE
Add single timezone parameter for logger.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,15 +52,14 @@ const (
 	"wire_encoding": "proto",
 	"log":  {
 		"level": "info",
+		"timezone": "UTC",
 		"formatter": {
-			"type": "json",
-			"timezone": "UTC"
+			"type": "json"
 		},
 		"output": {
 			"type": "file",
 			"file_pattern": "./snet-daemon.%Y%m%d.log",
 			"current_link": "./snet-daemon.log",
-			"clock_timezone": "UTC",
 			"rotation_time_in_sec": 86400,
 			"max_age_in_sec": 604800,
 			"rotation_count": 0

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,6 +13,7 @@ import (
 // Logger configuration keys
 const (
 	LogLevelKey     = "level"
+	LogTimezoneKey  = "timezone"
 	LogFormatterKey = "formatter"
 	LogOutputKey    = "output"
 	LogHooksKey     = "hooks"
@@ -51,15 +52,21 @@ func initLogger(logger *log.Logger, config *viper.Viper) error {
 	}
 	logger.SetLevel(level)
 
+	var timezone = config.GetString(LogTimezoneKey)
+
 	var formatter log.Formatter
-	formatter, err = newFormatterByConfig(config.Sub(LogFormatterKey))
+	var formatterConfig = config.Sub(LogFormatterKey)
+	formatterConfig.SetDefault(LogFormatterTimezoneKey, timezone)
+	formatter, err = newFormatterByConfig(formatterConfig)
 	if err != nil {
 		return fmt.Errorf("Unable initialize log formatter, error: %v", err)
 	}
 	logger.SetFormatter(formatter)
 
 	var output io.Writer
-	output, err = newOutputByConfig(config.Sub(LogOutputKey))
+	var outputConfig = config.Sub(LogOutputKey)
+	outputConfig.SetDefault(LogOutputFileClockTimezoneKey, timezone)
+	output, err = newOutputByConfig(outputConfig)
 	if err != nil {
 		return fmt.Errorf("Unable initialize log output, error: %v", err)
 	}


### PR DESCRIPTION
Working on issue https://github.com/singnet/snet-daemon/issues/27

Add logger "timezone" parameter to configure formatter and output timezone at once. Fix unit tests accordingly. Improve previous unit tests.