### PR TITLE
#63 Using embedded etcd server as a payment channel storage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,8 +22,8 @@
 [[projects]]
   name = "github.com/coreos/bbolt"
   packages = ["."]
-  revision = "583e8937c61f1af6513608ccc75c97b6abdf4ff9"
-  version = "v1.3.0"
+  revision = "7ee3ded59d4835e10f3e7d0f7603c42aa5e83820"
+  version = "v1.3.1-etcd.8"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/coreos/bbolt"
-  version = "1.3.0"
+  version = "v1.3.1-etcd.8"
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -9,7 +9,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"

--- a/blockchain/job.go
+++ b/blockchain/job.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/blockchain/tasks.go
+++ b/blockchain/tasks.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"

--- a/db/db.go
+++ b/db/db.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/pkg/errors"
 )
 

--- a/escrow/storage.go
+++ b/escrow/storage.go
@@ -2,7 +2,7 @@ package escrow
 
 import (
 	"errors"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/singnet/snet-daemon/blockchain"
 	log "github.com/sirupsen/logrus"
 )

--- a/etcddb/README.md
+++ b/etcddb/README.md
@@ -29,6 +29,9 @@ contain the JSON map with name *PAYMENT_CHANNEL_STORAGE_SERVER* and values:
 | ENABLED     | enable running embedded etcd server                |true         |
 
 
+`Note`:  If *PAYMENT_CHANNEL_STORAGE_SERVER* field is not set in the configuration file its *ENABLED*
+field is set to *false* by default and in this case the etcd server is not started.
+
 Schema, host, and CLIENT_PORT/PEER_PORT are used together to compose etcd listen-client-urls/listen-peer-urls
 (see the link below).
 

--- a/etcddb/README.md
+++ b/etcddb/README.md
@@ -9,7 +9,7 @@ This field is used both by etcd server and client:
 
 ```json
 {
-  "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380"
+  "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-2=http://127.0.0.2:2380,storage-3=http://127.0.0.3:2380"
 }
 ```
 
@@ -20,12 +20,12 @@ contain the JSON map with name *PAYMENT_CHANNEL_STORAGE_SERVER* and values:
 
 | Field name  | Description                                        |Default Value|
 |-------------|----------------------------------------------------|-------------|
-| ID          | unique name of the etcd server node                |             |
+| ID          | unique name of the etcd server node                |storage-1    |
 | SCHEMA      | URL schema used to create client and peer and urls |http         |
-| HOST        | host where the etcd server is executed             |             |
+| HOST        | host where the etcd server is executed             |127.0.0.1    |
 | CLIENT_PORT | port to listen clients requests                    |2379         |
 | PEER_PORT   | port to listen etcd peers                          |2380         |
-| TOKEN       | unique initial cluster token                       |             |
+| TOKEN       | unique initial cluster token                       |unique-token |
 | ENABLED     | enable running embedded etcd server                |true         |
 
 
@@ -44,7 +44,7 @@ Config for snet-daemon that does not run embedded etcd node:
 
 ```json
 {
-  "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380"
+  "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-2=http://127.0.0.2:2380,storage-3=http://127.0.0.3:2380"
 }
 ```
 
@@ -55,11 +55,11 @@ Config for snet-daemon that runs embedded etcd node:
     "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
 
     "PAYMENT_CHANNEL_STORAGE_SERVER": {
-        "ID": "storage_1",
+        "ID": "storage-1",
         "HOST" : "127.0.0.1",
         "CLIENT_PORT": 2379,
         "PEER_PORT": 2380,
-        "TOKEN": "payment_channel_storage_token",
+        "TOKEN": "unique-token",
         "ENABLED": true
     }
 }
@@ -69,14 +69,14 @@ Note that it is possible to disable running an embedded etcd server in the confi
 
 ```json
 {
-    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
+    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-1=http://127.0.0.1:2380,storage-2=http://127.0.0.2:2380,storage-3=http://127.0.0.3:2380",
 
     "PAYMENT_CHANNEL_STORAGE_SERVER": {
-        "ID": "storage_2",
+        "ID": "storage-2",
         "HOST" : "127.0.0.2",
         "CLIENT_PORT": 2379,
         "PEER_PORT": 2380,
-        "TOKEN": "payment_channel_storage_token",
+        "TOKEN": "unique-token",
         "ENABLED": false
     }
 }
@@ -94,11 +94,11 @@ Note that it is possible to disable running an embedded etcd server in the confi
 
 ```json
 {
-    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
+    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-1=http://127.0.0.1:2380,storage-2=http://127.0.0.2:2380,storage-3=http://127.0.0.3:2380",
 
     "PAYMENT_CHANNEL_STORAGE_CLIENT": {
-        "CONNECTION_TIMEOUT": 2379,
-        "REQUEST_TIMEOUT": 2380
+        "CONNECTION_TIMEOUT": 5,
+        "REQUEST_TIMEOUT": 3
     }
 }
 ```

--- a/etcddb/README.md
+++ b/etcddb/README.md
@@ -1,0 +1,52 @@
+#  etcd Payment Channel Storage
+
+This is an implementation of the Payment Channel Storage based on etcd.
+
+# Config file
+
+It is possible to configure snet-daemon to run with or without embedded etcd server.
+
+In both ways the configuration file must include *PAYMENT_CHANNEL_STORAGE_CLUSTER* field which contains a comma
+separated list of values *etcd_node_name=host:client_port*.
+
+Config for snet-daemon that does not run embedded etcd node:
+
+```json
+	{
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380"
+	}
+```
+
+Config for snet-daemon that runs embedded etcd node:
+
+```json
+	{
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
+
+		"PAYMENT_CHANNEL_STORAGE": {
+			"ID": "storage_1",
+			"HOST" : "127.0.0.1",
+			"CLIENT_PORT": 2379,
+			"PEER_PORT": 2380,
+			"TOKEN": "payment_channel_storage_token",
+			"ENABLED": true
+		}
+	}
+```
+
+Note that it is possible to disable running an embedded etcd server in the config file by setting *ENABLED* field to false:
+
+```json
+	{
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
+
+		"PAYMENT_CHANNEL_STORAGE": {
+			"ID": "storage_2",
+			"HOST" : "127.0.0.2",
+			"CLIENT_PORT": 2379,
+			"PEER_PORT": 2380,
+			"TOKEN": "payment_channel_storage_token",
+			"ENABLED": false
+		}
+	}
+```

--- a/etcddb/README.md
+++ b/etcddb/README.md
@@ -2,12 +2,43 @@
 
 This is an implementation of the Payment Channel Storage based on etcd.
 
-# Config file
+The configuration file must include *PAYMENT_CHANNEL_STORAGE_CLUSTER* field which contains a comma
+separated list of values *etcd_node_name=host:client_port*.
+
+This field is used both by etcd server and client:
+
+```json
+{
+  "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380"
+}
+```
+
+# etcd server configuration
+
+To use embedded etcd server in snet-daemon the configuration file needs to
+contain the JSON map with name *PAYMENT_CHANNEL_STORAGE_SERVER* and values:
+
+| Field name  | Description                                        |Default Value|
+|-------------|----------------------------------------------------|-------------|
+| ID          | unique name of the etcd server node                |             |
+| SCHEMA      | URL schema used to create client and peer and urls |http         |
+| HOST        | host where the etcd server is executed             |             |
+| CLIENT_PORT | port to listen clients requests                    |2379         |
+| PEER_PORT   | port to listen etcd peers                          |2380         |
+| TOKEN       | unique initial cluster token                       |             |
+| ENABLED     | enable running embedded etcd server                |true         |
+
+
+Schema, host, and CLIENT_PORT/PEER_PORT are used together to compose etcd listen-client-urls/listen-peer-urls
+(see the link below).
+
+Using unique token, etcd can generate unique cluster IDs and member IDs for the clusters even if they otherwise have
+the exact same configuration. This can protect etcd from cross-cluster-interaction, which might corrupt the clusters.
+
+For more details see
+[etcd Clustering Guide](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/clustering.md) link.
 
 It is possible to configure snet-daemon to run with or without embedded etcd server.
-
-In both ways the configuration file must include *PAYMENT_CHANNEL_STORAGE_CLUSTER* field which contains a comma
-separated list of values *etcd_node_name=host:client_port*.
 
 Config for snet-daemon that does not run embedded etcd node:
 
@@ -23,7 +54,7 @@ Config for snet-daemon that runs embedded etcd node:
 {
     "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
 
-    "PAYMENT_CHANNEL_STORAGE": {
+    "PAYMENT_CHANNEL_STORAGE_SERVER": {
         "ID": "storage_1",
         "HOST" : "127.0.0.1",
         "CLIENT_PORT": 2379,
@@ -40,13 +71,34 @@ Note that it is possible to disable running an embedded etcd server in the confi
 {
     "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
 
-    "PAYMENT_CHANNEL_STORAGE": {
+    "PAYMENT_CHANNEL_STORAGE_SERVER": {
         "ID": "storage_2",
         "HOST" : "127.0.0.2",
         "CLIENT_PORT": 2379,
         "PEER_PORT": 2380,
         "TOKEN": "payment_channel_storage_token",
         "ENABLED": false
+    }
+}
+```
+
+# etcd client configuration
+
+*PAYMENT_CHANNEL_STORAGE_CLIENT* JSON map can be used to configure payment channel storage etcd client.
+
+| Field name         | Description                                   |Default Value|
+|--------------------|-----------------------------------------------|-------------|
+| CONNECTION_TIMEOUT | timeout for failing to establish a connection |5            |
+| REQUEST_TIMEOUT    | per request timeout                           |3            |
+
+
+```json
+{
+    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
+
+    "PAYMENT_CHANNEL_STORAGE_CLIENT": {
+        "CONNECTION_TIMEOUT": 2379,
+        "REQUEST_TIMEOUT": 2380
     }
 }
 ```

--- a/etcddb/README.md
+++ b/etcddb/README.md
@@ -12,41 +12,41 @@ separated list of values *etcd_node_name=host:client_port*.
 Config for snet-daemon that does not run embedded etcd node:
 
 ```json
-	{
-		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380"
-	}
+{
+  "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380"
+}
 ```
 
 Config for snet-daemon that runs embedded etcd node:
 
 ```json
-	{
-		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
+{
+    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
 
-		"PAYMENT_CHANNEL_STORAGE": {
-			"ID": "storage_1",
-			"HOST" : "127.0.0.1",
-			"CLIENT_PORT": 2379,
-			"PEER_PORT": 2380,
-			"TOKEN": "payment_channel_storage_token",
-			"ENABLED": true
-		}
-	}
+    "PAYMENT_CHANNEL_STORAGE": {
+        "ID": "storage_1",
+        "HOST" : "127.0.0.1",
+        "CLIENT_PORT": 2379,
+        "PEER_PORT": 2380,
+        "TOKEN": "payment_channel_storage_token",
+        "ENABLED": true
+    }
+}
 ```
 
 Note that it is possible to disable running an embedded etcd server in the config file by setting *ENABLED* field to false:
 
 ```json
-	{
-		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
+{
+    "PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380,storage_2=http://127.0.0.2:2380,storage_3=http://127.0.0.3:2380",
 
-		"PAYMENT_CHANNEL_STORAGE": {
-			"ID": "storage_2",
-			"HOST" : "127.0.0.2",
-			"CLIENT_PORT": 2379,
-			"PEER_PORT": 2380,
-			"TOKEN": "payment_channel_storage_token",
-			"ENABLED": false
-		}
-	}
+    "PAYMENT_CHANNEL_STORAGE": {
+        "ID": "storage_2",
+        "HOST" : "127.0.0.2",
+        "CLIENT_PORT": 2379,
+        "PEER_PORT": 2380,
+        "TOKEN": "payment_channel_storage_token",
+        "ENABLED": false
+    }
+}
 ```

--- a/etcddb/etcddb_client.go
+++ b/etcddb/etcddb_client.go
@@ -1,0 +1,89 @@
+package etcddb
+
+import (
+	"context"
+	"time"
+
+	"go.etcd.io/etcd/clientv3"
+)
+
+// EtcdClient struct has some useful methods to wolrk with etcd client
+type EtcdClient struct {
+	timeout time.Duration
+	etcdv3  *clientv3.Client
+}
+
+// NewEtcdClient create new etcd storage client
+func NewEtcdClient(connectionTimeout time.Duration, callTimeout time.Duration, endpoints []string) (*EtcdClient, error) {
+	etcdv3, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: connectionTimeout,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &EtcdClient{timeout: callTimeout, etcdv3: etcdv3}, nil
+}
+
+// Get gets value from etcd by key
+func (client *EtcdClient) Get(key []byte) ([]byte, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
+	response, err := client.etcdv3.Get(ctx, byteArraytoString(key))
+	defer cancel()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, kv := range response.Kvs {
+		return kv.Value, nil
+	}
+	return nil, nil
+}
+
+// Put puts key and value to etcd
+func (client *EtcdClient) Put(key []byte, value []byte) error {
+
+	etcdv3 := client.etcdv3
+	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
+	_, err := etcdv3.Put(ctx, byteArraytoString(key), byteArraytoString(value))
+	defer cancel()
+
+	return err
+}
+
+// CompareAndSet uses CAS operation to set a value
+func (client *EtcdClient) CompareAndSet(key []byte, expect []byte, update []byte) (bool, error) {
+
+	etcdv3 := client.etcdv3
+	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
+	defer cancel()
+
+	response, err := etcdv3.KV.Txn(ctx).If(
+		clientv3.Compare(clientv3.Value(byteArraytoString(key)), "=", byteArraytoString(expect)),
+	).Then(
+		clientv3.OpPut(byteArraytoString(key), byteArraytoString(update)),
+	).Commit()
+
+	if err != nil {
+		return false, err
+	}
+
+	return response.Succeeded, nil
+}
+
+// Close closes etcd client
+func (client *EtcdClient) Close() {
+	client.etcdv3.Close()
+}
+
+func byteArraytoString(bytes []byte) string {
+	return string(bytes)
+}
+
+func stringToByteArray(str string) []byte {
+	return []byte(str)
+}

--- a/etcddb/etcddb_client.go
+++ b/etcddb/etcddb_client.go
@@ -70,8 +70,9 @@ func NewEtcdClient(vip *viper.Viper) (client *EtcdClient, err error) {
 func (client *EtcdClient) Get(key []byte) ([]byte, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
-	response, err := client.etcdv3.Get(ctx, byteArraytoString(key))
 	defer cancel()
+
+	response, err := client.etcdv3.Get(ctx, byteArraytoString(key))
 
 	if err != nil {
 		return nil, err
@@ -88,8 +89,9 @@ func (client *EtcdClient) Put(key []byte, value []byte) error {
 
 	etcdv3 := client.etcdv3
 	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
-	_, err := etcdv3.Put(ctx, byteArraytoString(key), byteArraytoString(value))
 	defer cancel()
+
+	_, err := etcdv3.Put(ctx, byteArraytoString(key), byteArraytoString(value))
 
 	return err
 }

--- a/etcddb/etcddb_client.go
+++ b/etcddb/etcddb_client.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	// DefaultConnectionTimeout connection timeout in seconds
-	DefaultConnectionTimeout = 5
+	// DefaultConnectionTimeout default connection timeout in milliseconds
+	DefaultConnectionTimeout = 5000
 
-	// DefaultRequestTimeout connection timeout in seconds
-	DefaultRequestTimeout = 5
+	// DefaultRequestTimeout default request timeout in milliseconds
+	DefaultRequestTimeout = 3000
 )
 
 // EtcdClient struct has some useful methods to wolrk with etcd client
@@ -49,7 +49,7 @@ func NewEtcdClient(vip *viper.Viper) (client *EtcdClient, err error) {
 		}
 	}
 
-	connectionTimeout := time.Duration(conf.ConnectionTimeout) * time.Second
+	connectionTimeout := time.Duration(conf.ConnectionTimeout) * time.Millisecond
 
 	etcdv3, err := clientv3.New(clientv3.Config{
 		Endpoints:   endpoints,
@@ -60,7 +60,7 @@ func NewEtcdClient(vip *viper.Viper) (client *EtcdClient, err error) {
 		return
 	}
 
-	requestTimeout := time.Duration(conf.RequestTimeout) * time.Second
+	requestTimeout := time.Duration(conf.RequestTimeout) * time.Millisecond
 	client = &EtcdClient{timeout: requestTimeout, etcdv3: etcdv3}
 
 	return

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -1,0 +1,92 @@
+package etcddb
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/spf13/viper"
+	"go.etcd.io/etcd/embed"
+)
+
+// InitEtcdServer run etcd server according to the config
+func InitEtcdServer(vip *viper.Viper) (etcd *embed.Etcd, err error) {
+
+	cluster := GetPaymentChannelCluster(vip)
+
+	conf, err := GetPaymentChannelStorageConf(vip)
+
+	if err != nil || conf == nil || !conf.Enabled {
+		return
+	}
+
+	return StartEtcdServer(conf, cluster)
+}
+
+// StartEtcdServer starts ectd server
+// The method blocks until the server is started
+// or failed by timeout
+func StartEtcdServer(
+	conf *PaymentChannelStorageConf,
+	cluster string,
+) (etcd *embed.Etcd, err error) {
+
+	etcdConf := getEtcdConf(conf, cluster)
+	etcd, err = embed.StartEtcd(etcdConf)
+
+	if err != nil {
+		return
+	}
+
+	select {
+	case <-etcd.Server.ReadyNotify():
+	case <-time.After(60 * time.Second):
+		etcd.Server.Stop()
+		return nil, errors.New("etcd server took too long to start: " + conf.ID)
+	}
+
+	return
+}
+
+func getEtcdConf(conf *PaymentChannelStorageConf, cluster string) *embed.Config {
+
+	clientURL := &url.URL{
+		Scheme: conf.Scheme,
+		Host:   fmt.Sprintf("%s:%d", conf.Host, conf.ClientPort),
+	}
+
+	peerURL := &url.URL{
+		Scheme: conf.Scheme,
+		Host:   fmt.Sprintf("%s:%d", conf.Host, conf.PeerPort),
+	}
+
+	fmt.Printf("name: '%s'\n", conf.ID)
+	fmt.Printf("client url: '%v'\n", clientURL)
+	fmt.Printf("peer   url: '%v'\n", peerURL)
+	fmt.Printf("initial cluster: '%s'\n", cluster)
+
+	etcdConf := embed.NewConfig()
+	etcdConf.Name = conf.ID
+	etcdConf.Dir = conf.ID + ".etcd"
+
+	// --listen-client-urls
+	etcdConf.LCUrls = []url.URL{*clientURL}
+
+	// --advertise-client-urls
+	etcdConf.ACUrls = []url.URL{*clientURL}
+
+	// --listen-peer-urls
+	etcdConf.LPUrls = []url.URL{*peerURL}
+
+	// --initial-advertise-peer-urls
+	etcdConf.APUrls = []url.URL{*peerURL}
+
+	// --initial-cluster
+	etcdConf.InitialCluster = cluster
+
+	//  --initial-cluster-state
+	etcdConf.ClusterState = embed.ClusterStateFlagNew
+
+	return etcdConf
+}

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -82,7 +82,7 @@ func getEtcdConf(conf *PaymentChannelStorageServerConf, cluster string) *embed.C
 		"client url":      clientURL,
 		"peer   url":      peerURL,
 		"initial cluster": cluster,
-	}).Debug()
+	}).Info()
 
 	etcdConf := embed.NewConfig()
 	etcdConf.Name = conf.ID

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"go.etcd.io/etcd/embed"
 )
@@ -76,10 +77,12 @@ func getEtcdConf(conf *PaymentChannelStorageServerConf, cluster string) *embed.C
 		Host:   fmt.Sprintf("%s:%d", conf.Host, conf.PeerPort),
 	}
 
-	fmt.Printf("name: '%s'\n", conf.ID)
-	fmt.Printf("client url: '%v'\n", clientURL)
-	fmt.Printf("peer   url: '%v'\n", peerURL)
-	fmt.Printf("initial cluster: '%s'\n", cluster)
+	log.WithFields(log.Fields{
+		"etcd id":         conf.ID,
+		"client url":      clientURL,
+		"peer   url":      peerURL,
+		"initial cluster": cluster,
+	}).Debug()
 
 	etcdConf := embed.NewConfig()
 	etcdConf.Name = conf.ID

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -23,7 +23,7 @@ func InitEtcdServer(vip *viper.Viper) (server *EtcdServer, err error) {
 
 	cluster := GetPaymentChannelCluster(vip)
 
-	conf, err := GetPaymentChannelStorageConf(vip)
+	conf, err := GetPaymentChannelStorageServerConf(vip)
 
 	if err != nil || conf == nil || !conf.Enabled {
 		return
@@ -43,7 +43,7 @@ func (server *EtcdServer) Close() {
 // The method blocks until the server is started
 // or failed by timeout
 func startEtcdServer(
-	conf *PaymentChannelStorageConf,
+	conf *PaymentChannelStorageServerConf,
 	cluster string,
 ) (etcd *embed.Etcd, err error) {
 
@@ -64,7 +64,7 @@ func startEtcdServer(
 	return
 }
 
-func getEtcdConf(conf *PaymentChannelStorageConf, cluster string) *embed.Config {
+func getEtcdConf(conf *PaymentChannelStorageServerConf, cluster string) *embed.Config {
 
 	clientURL := &url.URL{
 		Scheme: conf.Scheme,
@@ -99,6 +99,9 @@ func getEtcdConf(conf *PaymentChannelStorageConf, cluster string) *embed.Config 
 
 	// --initial-cluster
 	etcdConf.InitialCluster = cluster
+
+	//--initial-cluster-token
+	etcdConf.InitialClusterToken = conf.Token
 
 	//  --initial-cluster-state
 	etcdConf.ClusterState = embed.ClusterStateFlagNew

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -1,7 +1,6 @@
 package etcddb
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/singnet/snet-daemon/config"
@@ -9,46 +8,80 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type PaymentChannelStorageConf struct {
-	ID         string
-	ClientPort int `mapstructure:"CLIENT_PORT"`
-	PeerPort   int `mapstructure:"PEER_PORT"`
-	Token      string
+func TestEmptyPaymentChannelStorageConf(t *testing.T) {
+
+	const confJSON = `
+	{
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380"
+	}`
+
+	vip := readConfig(t, confJSON)
+
+	cluster := GetPaymentChannelCluster(vip)
+	assert.Equal(t, "storage_1=http://127.0.0.1:2380", cluster)
+
+	conf, err := GetPaymentChannelStorageConf(vip)
+	assert.Nil(t, err)
+	assert.Nil(t, conf)
+
 }
 
 func TestConfigParsing(t *testing.T) {
 
-	const conf = `
+	const confJSON = `
 	{
-		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2480",
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
 
 		"PAYMENT_CHANNEL_STORAGE": {
 			"ID": "storage_1",
 			"CLIENT_PORT": 2379,
 			"PEER_PORT": 2380,
-			"TOKEN": "payment_channel_storage_token"
+			"TOKEN": "payment_channel_storage_token",
+			"ENABLED": true
 		}
 	}`
 
-	vip := readConfig(t, conf)
+	vip := readConfig(t, confJSON)
 
-	cluster := vip.GetString("PAYMENT_CHANNEL_STORAGE_CLUSTER")
-	assert.Equal(t, "storage_1=http://127.0.0.1:2480", cluster)
+	cluster := GetPaymentChannelCluster(vip)
+	assert.Equal(t, "storage_1=http://127.0.0.1:2380", cluster)
 
-	var paymentChannelStorageConf = PaymentChannelStorageConf{}
-	err := vip.UnmarshalKey("PAYMENT_CHANNEL_STORAGE", &paymentChannelStorageConf)
-
-	if err != nil {
-		fmt.Println(err)
-	}
+	conf, err := GetPaymentChannelStorageConf(vip)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, paymentChannelStorageConf)
+	assert.NotNil(t, conf)
 
-	assert.Equal(t, "storage_1", paymentChannelStorageConf.ID)
-	assert.Equal(t, 2379, paymentChannelStorageConf.ClientPort)
-	assert.Equal(t, 2380, paymentChannelStorageConf.PeerPort)
-	assert.Equal(t, "payment_channel_storage_token", paymentChannelStorageConf.Token)
+	assert.Equal(t, "storage_1", conf.ID)
+	assert.Equal(t, 2379, conf.ClientPort)
+	assert.Equal(t, 2380, conf.PeerPort)
+	assert.Equal(t, "payment_channel_storage_token", conf.Token)
+	assert.Equal(t, true, conf.Enabled)
+}
+
+func TestPaymentChannelStorageConf(t *testing.T) {
+
+	const confJSON = `
+	{
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",
+
+		"PAYMENT_CHANNEL_STORAGE": {
+			"ID": "storage_1",
+			"HOST" : "127.0.0.1",			
+			"CLIENT_PORT": 2379,
+			"PEER_PORT": 2380,
+			"TOKEN": "payment_channel_storage_token",
+			"ENABLED": true
+		}
+	}`
+
+	vip := readConfig(t, confJSON)
+
+	etcd, err := InitEtcdServer(vip)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, etcd)
+
+	defer etcd.Close()
 }
 
 func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -1,0 +1,57 @@
+package etcddb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/singnet/snet-daemon/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+type PaymentChannelStorageConf struct {
+	ID             string
+	ClientPort     int `mapstructure:"CLIENT_PORT"`
+	PeerPort       int `mapstructure:"PEER_PORT"`
+	Token          string
+	StorageCluster string `mapstructure:"STORAGE_CLUSTER"`
+}
+
+func TestConfigParsing(t *testing.T) {
+
+	const conf = `
+	{
+		"TEST": "test_value",
+		"PAYMENT_CHANNEL_STORAGE": {
+			"ID": "storage_1",
+			"CLIENT_PORT": 2379,
+			"PEER_PORT": 2380,
+			"TOKEN": "payment_channel_storage_token",
+			"STORAGE_CLUSTER" : "storage_1=http://127.0.0.1:2480"
+		}
+	}`
+
+	vip := readConfig(t, conf)
+	var paymentChannelStorageConf = PaymentChannelStorageConf{}
+	err := vip.UnmarshalKey("PAYMENT_CHANNEL_STORAGE", &paymentChannelStorageConf)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentChannelStorageConf)
+
+	assert.Equal(t, "storage_1", paymentChannelStorageConf.ID)
+	assert.Equal(t, 2379, paymentChannelStorageConf.ClientPort)
+	assert.Equal(t, 2380, paymentChannelStorageConf.PeerPort)
+	assert.Equal(t, "payment_channel_storage_token", paymentChannelStorageConf.Token)
+	assert.Equal(t, "storage_1=http://127.0.0.1:2480", paymentChannelStorageConf.StorageCluster)
+}
+
+func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {
+	vip = viper.New()
+	err := config.ReadConfigFromJsonString(vip, configJSON)
+	assert.Nil(t, err)
+	return
+}

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -111,8 +111,8 @@ func TestDefaultEtcdClientConf(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, conf)
 
-	assert.Equal(t, 5, conf.ConnectionTimeout)
-	assert.Equal(t, 3, conf.RequestTimeout)
+	assert.Equal(t, 5000, conf.ConnectionTimeout)
+	assert.Equal(t, 3000, conf.RequestTimeout)
 }
 
 func TestEtcdClientConf(t *testing.T) {
@@ -122,8 +122,8 @@ func TestEtcdClientConf(t *testing.T) {
 		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-1=http://127.0.0.1:2380",
 
 		"PAYMENT_CHANNEL_STORAGE_CLIENT": {
-			"CONNECTION_TIMEOUT": 15,
-			"REQUEST_TIMEOUT": 5
+			"CONNECTION_TIMEOUT": 15000,
+			"REQUEST_TIMEOUT": 5000
 		}
 	}`
 
@@ -135,8 +135,8 @@ func TestEtcdClientConf(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, conf)
-	assert.Equal(t, 15, conf.ConnectionTimeout)
-	assert.Equal(t, 5, conf.RequestTimeout)
+	assert.Equal(t, 15000, conf.ConnectionTimeout)
+	assert.Equal(t, 5000, conf.RequestTimeout)
 }
 
 func TestPaymentChannelStorageReadWrite(t *testing.T) {
@@ -146,13 +146,13 @@ func TestPaymentChannelStorageReadWrite(t *testing.T) {
 		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-1=http://127.0.0.1:2380",
 
 		"PAYMENT_CHANNEL_STORAGE_CLIENT": {
-			"CONNECTION_TIMEOUT": 5,
-			"REQUEST_TIMEOUT": 3
+			"CONNECTION_TIMEOUT": 5000,
+			"REQUEST_TIMEOUT": 3000
 		},
 
 		"PAYMENT_CHANNEL_STORAGE_SERVER": {
 			"ID": "storage-1",
-			"HOST" : "127.0.0.1",			
+			"HOST" : "127.0.0.1",
 			"CLIENT_PORT": 2379,
 			"PEER_PORT": 2380,
 			"TOKEN": "unique-token",

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -25,6 +25,7 @@ func TestDefaultEtcdServerConf(t *testing.T) {
 	const confJSON = `{
 		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage-1=http://127.0.0.1:2380"
 	}`
+
 	vip := readConfig(t, confJSON)
 	conf, err := GetPaymentChannelStorageServerConf(vip)
 
@@ -36,13 +37,12 @@ func TestDefaultEtcdServerConf(t *testing.T) {
 	assert.Equal(t, 2379, conf.ClientPort)
 	assert.Equal(t, 2380, conf.PeerPort)
 	assert.Equal(t, "unique-token", conf.Token)
-	assert.Equal(t, true, conf.Enabled)
+	assert.Equal(t, false, conf.Enabled)
 
 	server, err := InitEtcdServer(vip)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, server)
-	defer server.Close()
+	assert.Nil(t, server)
 }
 
 func TestDisabledEtcdServerConf(t *testing.T) {

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -10,28 +10,31 @@ import (
 )
 
 type PaymentChannelStorageConf struct {
-	ID             string
-	ClientPort     int `mapstructure:"CLIENT_PORT"`
-	PeerPort       int `mapstructure:"PEER_PORT"`
-	Token          string
-	StorageCluster string `mapstructure:"STORAGE_CLUSTER"`
+	ID         string
+	ClientPort int `mapstructure:"CLIENT_PORT"`
+	PeerPort   int `mapstructure:"PEER_PORT"`
+	Token      string
 }
 
 func TestConfigParsing(t *testing.T) {
 
 	const conf = `
 	{
-		"TEST": "test_value",
+		"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2480",
+
 		"PAYMENT_CHANNEL_STORAGE": {
 			"ID": "storage_1",
 			"CLIENT_PORT": 2379,
 			"PEER_PORT": 2380,
-			"TOKEN": "payment_channel_storage_token",
-			"STORAGE_CLUSTER" : "storage_1=http://127.0.0.1:2480"
+			"TOKEN": "payment_channel_storage_token"
 		}
 	}`
 
 	vip := readConfig(t, conf)
+
+	cluster := vip.GetString("PAYMENT_CHANNEL_STORAGE_CLUSTER")
+	assert.Equal(t, "storage_1=http://127.0.0.1:2480", cluster)
+
 	var paymentChannelStorageConf = PaymentChannelStorageConf{}
 	err := vip.UnmarshalKey("PAYMENT_CHANNEL_STORAGE", &paymentChannelStorageConf)
 
@@ -46,7 +49,6 @@ func TestConfigParsing(t *testing.T) {
 	assert.Equal(t, 2379, paymentChannelStorageConf.ClientPort)
 	assert.Equal(t, 2380, paymentChannelStorageConf.PeerPort)
 	assert.Equal(t, "payment_channel_storage_token", paymentChannelStorageConf.Token)
-	assert.Equal(t, "storage_1=http://127.0.0.1:2480", paymentChannelStorageConf.StorageCluster)
 }
 
 func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {

--- a/etcddb/payment_channel_storage.go
+++ b/etcddb/payment_channel_storage.go
@@ -21,10 +21,14 @@ const (
 	// PaymentChannelStorageServerKey key for viper
 	PaymentChannelStorageServerKey = "payment_channel_storage_server"
 
-	// DefaultPaymentChannelStorageServerConf default server conf
+	// DefaultPaymentChannelStorageServerConf default server conf.
 	// Note that running snet-daemon with several replicas require
 	// that the default configuration file should be updated
-	// according to the real information about etcd nodes in cluster
+	// according to the real information about etcd nodes in cluster.
+	// Because DefaultPaymentChannelStorageServerConf is used when
+	// the PAYMENT_CHANNEL_STORAGE_SERVER field is not set in the
+	// property file it is treated as etcd server is not configured
+	// and the ENABLED in this case is set to false by default.
 	DefaultPaymentChannelStorageServerConf = `
 	{
         "ID": "storage-1",
@@ -32,7 +36,7 @@ const (
         "CLIENT_PORT": 2379,
         "PEER_PORT": 2380,
         "TOKEN": "unique-token",
-        "ENABLED": true
+        "ENABLED": false
     }`
 )
 

--- a/etcddb/payment_channel_storage.go
+++ b/etcddb/payment_channel_storage.go
@@ -5,15 +5,29 @@ import (
 )
 
 const (
-	// PaymentChannelStorageKey key for viper
-	PaymentChannelStorageKey = "payment_channel_storage"
+	// PaymentChannelStorageServerKey key for viper
+	PaymentChannelStorageServerKey = "payment_channel_storage_server"
 
-	// PaymentChannelStorageClusterKey key for viper
-	PaymentChannelStorageClusterKey = "payment_channel_storage_cluster"
+	// PaymentChannelStorageClientKey key for viper
+	PaymentChannelStorageClientKey = "payment_channel_storage_client"
 )
 
-// PaymentChannelStorageConf contains embedded etcd server conf
-type PaymentChannelStorageConf struct {
+// PaymentChannelStorageServerConf contains embedded etcd server config
+// ID - unique name of the etcd server node
+// Scheme - URL schema used to create client and peer and urls
+// Host - host where the etcd server is executed
+// ClientPort - port to listen clients, used together with
+//              Schema and host to compose listen-client-urls (see link below)
+// PeerPort - port to listen etcd peers, used together with
+//              Schema and host to compose listen-client-urls (see link below)
+// Token - unique initial cluster token. Using unique token etcd can generate unique
+//         cluster IDs and member IDs for the clusters even if they otherwise have
+//         the exact same configuration. This can protect etcd from
+//         cross-cluster-interaction, which might corrupt the clusters.
+// Enabled - enable running embedded etcd server
+// For more details see etcd Clustering Guide link:
+// https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/clustering.md
+type PaymentChannelStorageServerConf struct {
 	ID         string
 	Scheme     string
 	Host       string
@@ -28,14 +42,35 @@ func GetPaymentChannelCluster(vip *viper.Viper) string {
 	return vip.GetString("PAYMENT_CHANNEL_STORAGE_CLUSTER")
 }
 
-// GetPaymentChannelStorageConf gets PaymentChannelStorageConf from viper
-func GetPaymentChannelStorageConf(vip *viper.Viper) (conf *PaymentChannelStorageConf, err error) {
+// GetPaymentChannelStorageServerConf gets PaymentChannelStorageServerConf from viper
+func GetPaymentChannelStorageServerConf(vip *viper.Viper) (conf *PaymentChannelStorageServerConf, err error) {
 
-	if vip.Get(PaymentChannelStorageKey) == nil {
+	if vip.Get(PaymentChannelStorageServerKey) == nil {
 		return
 	}
 
-	conf = &PaymentChannelStorageConf{Scheme: "http", Enabled: true}
-	err = vip.UnmarshalKey(PaymentChannelStorageKey, conf)
+	conf = &PaymentChannelStorageServerConf{Scheme: "http", ClientPort: 2379, PeerPort: 2380, Enabled: true}
+	err = vip.UnmarshalKey(PaymentChannelStorageServerKey, conf)
+	return
+}
+
+// PaymentChannelStorageClientConf config
+// ConnectionTimeout - timeout for failing to establish a connection
+// RequestTimeout    - per request timeout
+type PaymentChannelStorageClientConf struct {
+	ConnectionTimeout int `mapstructure:"CONNECTION_TIMEOUT"`
+	RequestTimeout    int `mapstructure:"REQUEST_TIMEOUT"`
+}
+
+// GetPaymentChannelStorageClientConf gets PaymentChannelStorageServerConf from viper
+func GetPaymentChannelStorageClientConf(vip *viper.Viper) (conf *PaymentChannelStorageClientConf, err error) {
+
+	if vip.Get(PaymentChannelStorageClientKey) == nil {
+		return
+	}
+
+	conf = &PaymentChannelStorageClientConf{}
+	err = vip.UnmarshalKey(PaymentChannelStorageClientKey, conf)
+
 	return
 }

--- a/etcddb/payment_channel_storage.go
+++ b/etcddb/payment_channel_storage.go
@@ -1,0 +1,41 @@
+package etcddb
+
+import (
+	"github.com/spf13/viper"
+)
+
+const (
+	// PaymentChannelStorageKey key for viper
+	PaymentChannelStorageKey = "payment_channel_storage"
+
+	// PaymentChannelStorageClusterKey key for viper
+	PaymentChannelStorageClusterKey = "payment_channel_storage_cluster"
+)
+
+// PaymentChannelStorageConf contains embedded etcd server conf
+type PaymentChannelStorageConf struct {
+	ID         string
+	Scheme     string
+	Host       string
+	ClientPort int `mapstructure:"CLIENT_PORT"`
+	PeerPort   int `mapstructure:"PEER_PORT"`
+	Token      string
+	Enabled    bool
+}
+
+// GetPaymentChannelCluster gets payment channel cluster from viper
+func GetPaymentChannelCluster(vip *viper.Viper) string {
+	return vip.GetString("PAYMENT_CHANNEL_STORAGE_CLUSTER")
+}
+
+// GetPaymentChannelStorageConf gets PaymentChannelStorageConf from viper
+func GetPaymentChannelStorageConf(vip *viper.Viper) (conf *PaymentChannelStorageConf, err error) {
+
+	if vip.Get(PaymentChannelStorageKey) == nil {
+		return
+	}
+
+	conf = &PaymentChannelStorageConf{Scheme: "http", Enabled: true}
+	err = vip.UnmarshalKey(PaymentChannelStorageKey, conf)
+	return
+}

--- a/etcddb/payment_channel_storage.go
+++ b/etcddb/payment_channel_storage.go
@@ -14,8 +14,8 @@ const (
 	// DefaultPaymentChannelStorageClientConf default client conf
 	DefaultPaymentChannelStorageClientConf = `
 	{
-        "CONNECTION_TIMEOUT": 5,
-        "REQUEST_TIMEOUT": 3
+        "CONNECTION_TIMEOUT": 5000,
+        "REQUEST_TIMEOUT": 3000
     }`
 
 	// PaymentChannelStorageServerKey key for viper

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/gorilla/handlers"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/pkg/errors"


### PR DESCRIPTION
This is an initial fix which includes etcd as a payment storage into snet-daemon project.
It includes two main structures 
* EtcdServer
* EtcdClient
and some basic operations on it.

The etcddb_test.go test show basic usage like using a config file to start an etcd server and read/write values to it.

The example of the config file:
```
{
	"PAYMENT_CHANNEL_STORAGE_CLUSTER": "storage_1=http://127.0.0.1:2380",

	"PAYMENT_CHANNEL_STORAGE": {
		"ID": "storage_1",
		"HOST" : "127.0.0.1",			
		"CLIENT_PORT": 2379,
		"PEER_PORT": 2380,
		"TOKEN": "payment_channel_storage_token",
		"ENABLED": true
	}
}
``` 