### PR TITLE
Poll new payment channels from blockchain

### DIFF
--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -79,7 +79,7 @@ type PaymentChannelData struct {
 // id.
 type PaymentChannelStorage interface {
 	// Get returns channel information by channel id.
-	Get(key *PaymentChannelKey) (paymentChannel *PaymentChannelData, err error)
+	Get(key *PaymentChannelKey) (state *PaymentChannelData, err error)
 	// Put writes channel information by channel id.
 	Put(key *PaymentChannelKey, state *PaymentChannelData) (err error)
 	// CompareAndSwap atomically replaces old payment channel state by new

--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -78,13 +78,16 @@ type PaymentChannelData struct {
 // PaymentChannelStorage is an interface to get channel information by channel
 // id.
 type PaymentChannelStorage interface {
-	// Get returns channel information by channel id.
-	Get(key *PaymentChannelKey) (state *PaymentChannelData, err error)
+	// Get returns channel information by channel id. ok value indicates
+	// whether passed key was found. err indicates storage error.
+	Get(key *PaymentChannelKey) (state *PaymentChannelData, ok bool, err error)
 	// Put writes channel information by channel id.
 	Put(key *PaymentChannelKey, state *PaymentChannelData) (err error)
 	// CompareAndSwap atomically replaces old payment channel state by new
-	// state.
-	CompareAndSwap(key *PaymentChannelKey, prevState *PaymentChannelData, newState *PaymentChannelData) (err error)
+	// state. If ok flag is true and err is nil then operation was successful.
+	// If err is nil and ok is false then operation failed because prevState is
+	// not equal to current state. err indicates storage error.
+	CompareAndSwap(key *PaymentChannelKey, prevState *PaymentChannelData, newState *PaymentChannelData) (ok bool, err error)
 }
 
 func (key PaymentChannelKey) String() string {
@@ -173,9 +176,12 @@ func (h *escrowPaymentHandler) Payment(context *handler.GrpcStreamContext) (paym
 	}
 
 	channelKey := &PaymentChannelKey{channelID, channelNonce}
-	channel, e := h.storage.Get(channelKey)
+	channel, ok, e := h.storage.Get(channelKey)
 	if e != nil {
-		log.WithError(e).Warn("Payment channel not found")
+		return nil, status.Newf(codes.Internal, "payment channel storage error")
+	}
+	if !ok {
+		log.Warn("Payment channel not found")
 		return nil, status.Newf(codes.InvalidArgument, "payment channel \"%v\" not found", channelKey)
 	}
 
@@ -277,7 +283,7 @@ func bigIntToBytes(value *big.Int) []byte {
 
 func (h *escrowPaymentHandler) Complete(_payment handler.Payment) (err *status.Status) {
 	var payment = _payment.(*escrowPaymentType)
-	e := h.storage.CompareAndSwap(
+	ok, e := h.storage.CompareAndSwap(
 		payment.channelKey,
 		payment.channel,
 		&PaymentChannelData{
@@ -293,6 +299,11 @@ func (h *escrowPaymentHandler) Complete(_payment handler.Payment) (err *status.S
 		log.WithError(e).Error("Unable to store new payment channel state")
 		return status.New(codes.Internal, "unable to store new payment channel state")
 	}
+	if !ok {
+		log.WithField("payment", payment).Warn("Channel state was changed concurrently")
+		return status.Newf(codes.Unauthenticated, "state of payment channel \"%v\" was concurrently updated", payment.channelKey)
+	}
+
 	return
 }
 

--- a/escrow/storage.go
+++ b/escrow/storage.go
@@ -1,0 +1,59 @@
+package escrow
+
+import (
+	"errors"
+	"github.com/coreos/bbolt"
+	"github.com/singnet/snet-daemon/blockchain"
+	log "github.com/sirupsen/logrus"
+)
+
+type combinedStorage struct {
+	delegate PaymentChannelStorage
+}
+
+func NewCombinedStorage(processor *blockchain.Processor, delegate PaymentChannelStorage) PaymentChannelStorage {
+	return nil
+}
+
+func (storage *combinedStorage) Get(key *PaymentChannelKey) (state *PaymentChannelData, err error) {
+	log := log.WithField("key", key)
+
+	state, err = storage.delegate.Get(key)
+	if err == nil {
+		return
+	}
+	log.Info("Channel key is not found in storage")
+
+	state, err = storage.getChannelStateFromBlockchain(key)
+	if err != nil {
+		return
+	}
+	log.WithField("state", state).Info("Channel found in blockchain")
+
+	err = storage.CompareAndSwap(key, nil, state)
+	if err != nil {
+		log.Error("Cannot save channel in storage by key")
+		return
+	}
+	log.WithField("state", state).Info("Channel saved in storage")
+
+	return
+}
+
+func (storage *combinedStorage) getChannelStateFromBlockchain(key *PaymentChannelKey) (state *PaymentChannelData, err error) {
+	// TODO: implement
+	return nil, errors.New("not implemented yet")
+}
+
+func (storage *combinedStorage) Put(key *PaymentChannelKey, state *PaymentChannelData) (err error) {
+	return storage.delegate.Put(key, state)
+}
+
+func (storage *combinedStorage) CompareAndSwap(key *PaymentChannelKey, prevState *PaymentChannelData, newState *PaymentChannelData) (err error) {
+	return storage.delegate.CompareAndSwap(key, prevState, newState)
+}
+
+func NewDbStorage(db *bolt.DB) (storage PaymentChannelStorage) {
+	// TODO: implement
+	return nil
+}


### PR DESCRIPTION
Work on issue https://github.com/singnet/snet-daemon/issues/31

What is done:
- added payment channel storage which gets payment channel information from blockchain if it cannot find it in main storage
- payment channel storage API is improved to separate key absence and storage access error as suggested in https://github.com/singnet/snet-daemon/pull/59#discussion_r224355807