### PR TITLE
grpc-web: fix CORS issue with OPTIONS method in pre-flight requests from browsers

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/improbable-eng/grpc-web"
-  version = "0.6.2"
+  version = "0.6.3"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"


### PR DESCRIPTION
Fix to allow CORS pre-flight requests to daemon, allow CORS requests to unregistered (unknown) gRPC services