### PR TITLE
Print config to log on start.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
@@ -57,7 +59,7 @@ const (
 		"level": "info",
 		"timezone": "UTC",
 		"formatter": {
-			"type": "json"
+			"type": "text"
 		},
 		"output": {
 			"type": "file",
@@ -198,4 +200,22 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	}
 
 	return sub
+}
+
+var hiddenKeys = map[string]bool{
+	strings.ToUpper(PrivateKeyKey):       true,
+	strings.ToUpper(HdwalletMnemonicKey): true,
+}
+
+func LogConfig() {
+	log.Info("Final configuration:")
+	keys := vip.AllKeys()
+	sort.Strings(keys)
+	for _, key := range keys {
+		if hiddenKeys[strings.ToUpper(key)] {
+			log.Infof("%v: ***", key)
+		} else {
+			log.Infof("%v: %v", key, vip.Get(key))
+		}
+	}
 }

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -45,6 +45,7 @@ var ServeCmd = &cobra.Command{
 		if err != nil {
 			log.WithError(err).Fatal("Unable to initialize logger")
 		}
+		config.LogConfig()
 
 		var d daemon
 		d, err = newDaemon()
@@ -77,6 +78,7 @@ func loadConfigFileFromCommandLine(configFlag *pflag.Flag) {
 	} else {
 		log.Info("Configuration file is not set, using default configuration")
 	}
+
 }
 
 func isFileExist(fileName string) bool {


### PR DESCRIPTION
Print configuration on daemon start to know which configuration values are actually used.
Change default configuration format to text because json has random sorting.
Hide sensitive values.