### PR TITLE
Guarantee correct order of codec registering

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
-	_ "google.golang.org/grpc/encoding/proto" // guarantees correct codec registering order
+	_ "google.golang.org/grpc/encoding/proto" // ensure default "proto" codec is registered first
 )
 
 func init() {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/proto" // guarantees correct codec registering order
 )
 
 func init() {


### PR DESCRIPTION
Add fake import to guarantee that default protobuf codec is registered first.