### PR TITLE
Implement payment claim

### DIFF
--- a/snetd/cmd/claim.go
+++ b/snetd/cmd/claim.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	//"github.com/singnet/snet-daemon/blockchain"
 	"github.com/singnet/snet-daemon/escrow"
-	"github.com/singnet/snet-daemon/etcddb"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"math/big"
@@ -14,51 +14,76 @@ var ClaimCmd = &cobra.Command{
 	Short: "Claim money from payment channel",
 	Long:  "Increment payment channel nonce and send blockchain transaction to claim money from channel",
 	Run: func(cmd *cobra.Command, args []string) {
-		etcdStorage, err := etcddb.NewEtcdClient()
+		err := runAndCleanup(cmd, args)
 		if err != nil {
-			log.WithError(err).Fatal("Unable initialize etcd client")
+			log.Fatal(err.Error())
 		}
-
-		command := claimCommand{
-			channelId: &escrow.PaymentChannelKey{ID: big.NewInt(0)}, // TODO: get channelId from command line
-			storage:   escrow.NewPaymentChannelStorage(etcdStorage),
-		}
-
-		command.Run()
 	},
 }
 
+func runAndCleanup(cmd *cobra.Command, args []string) error {
+	components := InitComponents(cmd)
+	defer components.Close()
+
+	command := newClaimCommand(cmd, args, components)
+
+	return command.Run()
+}
+
 type claimCommand struct {
-	channelId *escrow.PaymentChannelKey
+	channelId *big.Int
 	storage   escrow.PaymentChannelStorage
+	channel   *escrow.PaymentChannelData
 }
 
-func (command *claimCommand) Run() {
-	channel := command.getChannel()
-
-	nextChannel := *channel
-	nextChannel.Nonce = (&big.Int{}).Add(channel.Nonce, big.NewInt(1))
-
-	command.updateChannel(channel, &nextChannel)
+func newClaimCommand(cmd *cobra.Command, args []string, components *Components) *claimCommand {
+	return &claimCommand{
+		channelId: getChannelId(cmd),
+		storage:   components.PaymentChannelStorage(),
+	}
 }
 
-func (command *claimCommand) getChannel() (channel *escrow.PaymentChannelData) {
-	channel, ok, err := command.storage.Get(command.channelId)
+func getChannelId(cmd *cobra.Command) (id *big.Int) {
+	// TODO: implement
+	return big.NewInt(0)
+}
+
+func (command *claimCommand) Run() (err error) {
+	err = command.getChannel()
 	if err != nil {
-		log.WithError(err).Fatal("Channel storage error")
+		return
+	}
+
+	err = command.incrementChannelNonce()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (command *claimCommand) getChannel() (err error) {
+	var ok bool
+	command.channel, ok, err = command.storage.Get(&escrow.PaymentChannelKey{ID: command.channelId})
+	if err != nil {
+		return fmt.Errorf("Channel storage error: %v", err)
 	}
 	if !ok {
-		log.WithField("channelId", command.channelId).Fatal("Channel is not found")
+		return fmt.Errorf("Channel is not found, channel id: %v", command.channelId)
 	}
-	return channel
+	return nil
 }
 
-func (command *claimCommand) updateChannel(currentChannel, nextChannel *escrow.PaymentChannelData) {
-	ok, err := command.storage.CompareAndSwap(command.channelId, currentChannel, nextChannel)
+func (command *claimCommand) incrementChannelNonce() (err error) {
+	nextChannel := *command.channel
+	nextChannel.Nonce = (&big.Int{}).Add(nextChannel.Nonce, big.NewInt(1))
+
+	ok, err := command.storage.CompareAndSwap(&escrow.PaymentChannelKey{ID: command.channelId}, command.channel, &nextChannel)
 	if err != nil {
-		log.WithError(err).Fatal("Channel storage error")
+		return fmt.Errorf("Channel storage error: %v", err)
 	}
 	if !ok {
-		log.WithField("channelId", command.channelId).Fatal("Channel was concurrently updated")
+		return fmt.Errorf("Channel was concurrently updated, channel id: %v", command.channelId)
 	}
+	return nil
 }

--- a/snetd/cmd/claim.go
+++ b/snetd/cmd/claim.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	//"github.com/singnet/snet-daemon/blockchain"
+	"github.com/singnet/snet-daemon/escrow"
+	"github.com/singnet/snet-daemon/etcddb"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"math/big"
 )
 
 var ClaimCmd = &cobra.Command{
@@ -9,6 +14,51 @@ var ClaimCmd = &cobra.Command{
 	Short: "Claim money from payment channel",
 	Long:  "Increment payment channel nonce and send blockchain transaction to claim money from channel",
 	Run: func(cmd *cobra.Command, args []string) {
+		etcdStorage, err := etcddb.NewEtcdClient()
+		if err != nil {
+			log.WithError(err).Fatal("Unable initialize etcd client")
+		}
 
+		command := claimCommand{
+			channelId: &escrow.PaymentChannelKey{ID: big.NewInt(0)}, // TODO: get channelId from command line
+			storage:   escrow.NewPaymentChannelStorage(etcdStorage),
+		}
+
+		command.Run()
 	},
+}
+
+type claimCommand struct {
+	channelId *escrow.PaymentChannelKey
+	storage   escrow.PaymentChannelStorage
+}
+
+func (command *claimCommand) Run() {
+	channel := command.getChannel()
+
+	nextChannel := *channel
+	nextChannel.Nonce = (&big.Int{}).Add(channel.Nonce, big.NewInt(1))
+
+	command.updateChannel(channel, &nextChannel)
+}
+
+func (command *claimCommand) getChannel() (channel *escrow.PaymentChannelData) {
+	channel, ok, err := command.storage.Get(command.channelId)
+	if err != nil {
+		log.WithError(err).Fatal("Channel storage error")
+	}
+	if !ok {
+		log.WithField("channelId", command.channelId).Fatal("Channel is not found")
+	}
+	return channel
+}
+
+func (command *claimCommand) updateChannel(currentChannel, nextChannel *escrow.PaymentChannelData) {
+	ok, err := command.storage.CompareAndSwap(command.channelId, currentChannel, nextChannel)
+	if err != nil {
+		log.WithError(err).Fatal("Channel storage error")
+	}
+	if !ok {
+		log.WithField("channelId", command.channelId).Fatal("Channel was concurrently updated")
+	}
 }

--- a/snetd/cmd/claim.go
+++ b/snetd/cmd/claim.go
@@ -22,7 +22,10 @@ var ClaimCmd = &cobra.Command{
 }
 
 func runAndCleanup(cmd *cobra.Command, args []string) (err error) {
-	components := InitComponents(cmd)
+	components, err := InitComponents(cmd)
+	if err != nil {
+		return
+	}
 	defer components.Close()
 
 	command, err := newClaimCommand(cmd, args, components)

--- a/snetd/cmd/claim.go
+++ b/snetd/cmd/claim.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var ClaimCmd = &cobra.Command{
+	Use:   "claim",
+	Short: "Claim money from payment channel",
+	Long:  "Increment payment channel nonce and send blockchain transaction to claim money from channel",
+	Run: func(cmd *cobra.Command, args []string) {
+
+	},
+}

--- a/snetd/cmd/components.go
+++ b/snetd/cmd/components.go
@@ -1,22 +1,153 @@
 package cmd
 
 import (
-	"github.com/singnet/snet-daemon/escrow"
+	"os"
+
+	"github.com/coreos/bbolt"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+
+	"github.com/singnet/snet-daemon/blockchain"
+	"github.com/singnet/snet-daemon/config"
+	"github.com/singnet/snet-daemon/db"
+	"github.com/singnet/snet-daemon/escrow"
+	"github.com/singnet/snet-daemon/handler"
 )
 
 type Components struct {
+	db                         *bbolt.DB
+	blockchain                 *blockchain.Processor
+	paymentChannelStorage      escrow.PaymentChannelStorage
+	grpcInterceptor            grpc.StreamServerInterceptor
+	paymentChannelStateService *escrow.PaymentChannelStateService
 }
 
-func InitComponents(cmd *cobra.Command) *Components {
-	// TODO: implement
+func InitComponents(cmd *cobra.Command) (components *Components, err error) {
+	components = &Components{}
+	defer func() {
+		if err != nil {
+			components.Close()
+			components = nil
+		}
+	}()
+
+	loadConfigFileFromCommandLine(cmd.Flags().Lookup("config"))
+
+	for _, init := range []func() error{
+		components.initDb,
+		components.initBlockchain,
+		components.initPaymentChannelStorage,
+		components.initGrpcInterceptor,
+		components.initPaymentChannelStateService,
+	} {
+		err = init()
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func loadConfigFileFromCommandLine(configFlag *pflag.Flag) {
+	var err error
+	var configFile = configFlag.Value.String()
+
+	// if file is not specified by user then configFile contains default name
+	if configFlag.Changed || isFileExist(configFile) {
+		err = config.LoadConfig(configFile)
+		if err != nil {
+			log.WithError(err).WithField("configFile", configFile).Fatal("Error reading configuration file")
+		}
+		log.WithField("configFile", configFile).Info("Using configuration file")
+	} else {
+		log.Info("Configuration file is not set, using default configuration")
+	}
+
+}
+
+func isFileExist(fileName string) bool {
+	_, err := os.Stat(fileName)
+	return !os.IsNotExist(err)
+}
+
+func (components *Components) initDb() (err error) {
+	if config.GetBool(config.BlockchainEnabledKey) {
+		if database, err := db.Connect(config.GetString(config.DbPathKey)); err != nil {
+			return errors.Wrap(err, "unable to initialize bbolt DB for blockchain state")
+		} else {
+			components.db = database
+		}
+	}
+	return
+}
+
+func (components *Components) initBlockchain() (err error) {
+	blockchain, err := blockchain.NewProcessor(components.db)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize blockchain processor")
+	}
+	components.blockchain = &blockchain
+	return
+}
+
+func (components *Components) initPaymentChannelStorage() (err error) {
+	components.paymentChannelStorage = escrow.NewCombinedStorage(
+		components.blockchain,
+		escrow.NewPaymentChannelStorage(escrow.NewMemStorage()),
+	)
+	return nil
+}
+
+func (components *Components) initGrpcInterceptor() (err error) {
+	if !components.blockchain.Enabled() {
+		log.Info("Blockchain is disabled: no payment validation")
+		components.grpcInterceptor = handler.NoOpInterceptor
+		return nil
+	}
+
+	log.Info("Blockchain is enabled: instantiate payment validation interceptor")
+	components.grpcInterceptor = handler.GrpcStreamInterceptor(
+		blockchain.NewJobPaymentHandler(components.blockchain),
+		escrow.NewEscrowPaymentHandler(
+			components.blockchain,
+			components.paymentChannelStorage,
+			escrow.NewIncomeValidator(components.blockchain),
+		),
+	)
+	return nil
+}
+
+func (components *Components) initPaymentChannelStateService() (err error) {
+	components.paymentChannelStateService = escrow.NewPaymentChannelStateService(components.PaymentChannelStorage())
 	return nil
 }
 
 func (components *Components) Close() {
+	if components.db != nil {
+		components.db.Close()
+	}
+}
+
+func (components *Components) DB() (db *bbolt.DB) {
+	return components.db
+}
+
+func (components *Components) Blockchain() (blockchain *blockchain.Processor) {
+	return components.blockchain
 }
 
 func (components *Components) PaymentChannelStorage() (storage escrow.PaymentChannelStorage) {
-	// TODO: implement
-	return nil
+	return components.paymentChannelStorage
+}
+
+func (components *Components) GrpcInterceptor() (interceptor grpc.StreamServerInterceptor) {
+	return components.grpcInterceptor
+}
+
+func (components *Components) PaymentChannelStateService() (service *escrow.PaymentChannelStateService) {
+	return components.paymentChannelStateService
 }

--- a/snetd/cmd/components.go
+++ b/snetd/cmd/components.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/singnet/snet-daemon/escrow"
+	"github.com/spf13/cobra"
+)
+
+type Components struct {
+}
+
+func InitComponents(cmd *cobra.Command) *Components {
+	// TODO: implement
+	return nil
+}
+
+func (components *Components) Close() {
+}
+
+func (components *Components) PaymentChannelStorage() (storage escrow.PaymentChannelStorage) {
+	// TODO: implement
+	return nil
+}

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -18,8 +18,13 @@ var RootCmd = &cobra.Command{
 	},
 }
 
+const (
+	ClaimChannelIdFlag = "channel-id"
+)
+
 var (
-	cfgFile            = RootCmd.PersistentFlags().StringP("config", "c", "snetd.config.json", "config file")
+	cfgFile = RootCmd.PersistentFlags().StringP("config", "c", "snetd.config.json", "config file")
+
 	autoSSLDomain      = ServeCmd.PersistentFlags().String("auto-ssl-domain", "", "enable SSL via LetsEncrypt for this domain (requires root)")
 	autoSSLCacheDir    = ServeCmd.PersistentFlags().String("auto-ssl-cache", ".certs", "auto-SSL certificate cache directory")
 	daemonType         = ServeCmd.PersistentFlags().StringP("type", "t", "grpc", "daemon type: one of 'grpc','http'")
@@ -35,6 +40,8 @@ var (
 	sslKeyPath         = ServeCmd.PersistentFlags().String("ssl-key", "", "SSL key file (.key)")
 	wireEncoding       = ServeCmd.PersistentFlags().String("wire-encoding", "proto", "message encoding: one of 'proto','json'")
 	pollSleep          = ServeCmd.PersistentFlags().String("poll-sleep", "5s", "blockchain poll sleep time")
+
+	claimChannelId = ClaimCmd.Flags().String(ClaimChannelIdFlag, "", "id of the payment channel to claim money")
 )
 
 func init() {
@@ -44,6 +51,8 @@ func init() {
 	RootCmd.AddCommand(InitCmd)
 	RootCmd.AddCommand(ServeCmd)
 	RootCmd.AddCommand(ClaimCmd)
+
+	ClaimCmd.MarkFlagRequired(ClaimChannelIdFlag)
 
 	vip.BindPFlag(config.AutoSSLDomainKey, serveCmdFlags.Lookup("auto-ssl-domain"))
 	vip.BindPFlag(config.AutoSSLCacheDirKey, serveCmdFlags.Lookup("auto-ssl-cache"))

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -43,6 +43,7 @@ func init() {
 
 	RootCmd.AddCommand(InitCmd)
 	RootCmd.AddCommand(ServeCmd)
+	RootCmd.AddCommand(ClaimCmd)
 
 	vip.BindPFlag(config.AutoSSLDomainKey, serveCmdFlags.Lookup("auto-ssl-domain"))
 	vip.BindPFlag(config.AutoSSLCacheDirKey, serveCmdFlags.Lookup("auto-ssl-cache"))

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -10,13 +10,11 @@ import (
 	"strings"
 	"syscall"
 
-	bolt "github.com/coreos/bbolt"
 	"github.com/gorilla/handlers"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/pkg/errors"
 	"github.com/singnet/snet-daemon/blockchain"
 	"github.com/singnet/snet-daemon/config"
-	"github.com/singnet/snet-daemon/db"
 	"github.com/singnet/snet-daemon/escrow"
 	"github.com/singnet/snet-daemon/etcddb"
 	"github.com/singnet/snet-daemon/handler"
@@ -25,7 +23,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
@@ -40,7 +37,11 @@ var ServeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 
-		loadConfigFileFromCommandLine(cmd.Flags().Lookup("config"))
+		components, err := InitComponents(cmd)
+		if err != nil {
+			log.WithError(err).Fatal("Unable to initialize daemon components")
+		}
+		defer components.Close()
 
 		err = logger.InitLogger(config.SubWithDefault(config.Vip(), config.LogKey))
 		if err != nil {
@@ -49,7 +50,7 @@ var ServeCmd = &cobra.Command{
 		config.LogConfig()
 
 		var d daemon
-		d, err = newDaemon()
+		d, err = newDaemon(components)
 		if err != nil {
 			log.WithError(err).Fatal("Unable to initialize daemon")
 		}
@@ -65,53 +66,25 @@ var ServeCmd = &cobra.Command{
 	},
 }
 
-func loadConfigFileFromCommandLine(configFlag *pflag.Flag) {
-	var err error
-	var configFile = configFlag.Value.String()
-
-	// if file is not specified by user then configFile contains default name
-	if configFlag.Changed || isFileExist(configFile) {
-		err = config.LoadConfig(configFile)
-		if err != nil {
-			log.WithError(err).WithField("configFile", configFile).Fatal("Error reading configuration file")
-		}
-		log.WithField("configFile", configFile).Info("Using configuration file")
-	} else {
-		log.Info("Configuration file is not set, using default configuration")
-	}
-
-}
-
-func isFileExist(fileName string) bool {
-	_, err := os.Stat(fileName)
-	return !os.IsNotExist(err)
-}
-
 type daemon struct {
 	autoSSLDomain string
 	acmeListener  net.Listener
 	grpcServer    *grpc.Server
 	blockProc     blockchain.Processor
 	lis           net.Listener
-	boltDB        *bolt.DB
 	sslCert       *tls.Certificate
 	etcdServer    *etcddb.EtcdServer
+	components    *Components
 }
 
-func newDaemon() (daemon, error) {
+func newDaemon(components *Components) (daemon, error) {
 	d := daemon{}
 
 	if err := config.Validate(); err != nil {
 		return d, err
 	}
 
-	if config.GetBool(config.BlockchainEnabledKey) {
-		if database, err := db.Connect(config.GetString(config.DbPathKey)); err != nil {
-			return d, errors.Wrap(err, "unable to initialize bolt DB for blockchain state")
-		} else {
-			d.boltDB = database
-		}
-	}
+	d.components = components
 
 	var err error
 	d.lis, err = net.Listen("tcp", fmt.Sprintf("0.0.0.0:%+v",
@@ -130,10 +103,7 @@ func newDaemon() (daemon, error) {
 		}
 	}
 
-	d.blockProc, err = blockchain.NewProcessor(d.boltDB)
-	if err != nil {
-		return d, errors.Wrap(err, "unable to initialize blockchain processor")
-	}
+	d.blockProc = *components.Blockchain()
 
 	if sslKey := config.GetString(config.SSLKeyPathKey); sslKey != "" {
 		cert, err := tls.LoadX509KeyPair(config.GetString(config.SSLCertPathKey), sslKey)
@@ -209,17 +179,12 @@ func (d daemon) start() {
 		d.lis = tls.NewListener(d.lis, tlsConfig)
 	}
 
-	paymentChannelStorage := escrow.NewCombinedStorage(
-		&d.blockProc,
-		escrow.NewPaymentChannelStorage(escrow.NewMemStorage()),
-	)
-
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
 		d.grpcServer = grpc.NewServer(
 			grpc.UnknownServiceHandler(handler.NewGrpcHandler()),
-			grpc.StreamInterceptor(d.getGrpcInterceptor(paymentChannelStorage)),
+			grpc.StreamInterceptor(d.components.GrpcInterceptor()),
 		)
-		escrow.RegisterPaymentChannelStateServiceServer(d.grpcServer, escrow.NewPaymentChannelStateService(paymentChannelStorage))
+		escrow.RegisterPaymentChannelStateServiceServer(d.grpcServer, d.components.PaymentChannelStateService())
 
 		mux := cmux.New(d.lis)
 		// Use "prefix" matching to support "application/grpc*" e.g. application/grpc+proto or +json
@@ -255,31 +220,10 @@ func (d daemon) start() {
 	}
 }
 
-func (d *daemon) getGrpcInterceptor(paymentChannelStorage escrow.PaymentChannelStorage) grpc.StreamServerInterceptor {
-	if !d.blockProc.Enabled() {
-		log.Info("Blockchain is disabled: no payment validation")
-		return handler.NoOpInterceptor
-	}
-
-	log.Info("Blockchain is enabled: instantiate payment validation interceptor")
-	return handler.GrpcStreamInterceptor(
-		blockchain.NewJobPaymentHandler(&d.blockProc),
-		escrow.NewEscrowPaymentHandler(
-			&d.blockProc,
-			paymentChannelStorage,
-			escrow.NewIncomeValidator(&d.blockProc),
-		),
-	)
-}
-
 func (d daemon) stop() {
 
 	if d.etcdServer != nil {
 		d.etcdServer.Close()
-	}
-
-	if d.boltDB != nil {
-		d.boltDB.Close()
 	}
 
 	if d.grpcServer != nil {


### PR DESCRIPTION
Work on issue https://github.com/singnet/snet-daemon/issues/72

What is done:
- claim command is added to daemon to claim money from the payment channel
- current implementation increments payment channel nonce but not sends transaction to the blockchain
- common components between serve.go and claim.go are moved into components.go in order to share initialization code and separate dependency injection from business logic

What's next:
- add a call of MultiPartyEscrow contract to claim the money