### PR TITLE
Implement channel claim part 2

### DIFF
--- a/blockchain/escrow.go
+++ b/blockchain/escrow.go
@@ -1,0 +1,59 @@
+package blockchain
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	log "github.com/sirupsen/logrus"
+)
+
+func (processor *Processor) ClaimFundsFromChannel(timeout time.Duration, channelId, amount *big.Int, signature []byte, sendBack bool) (err error) {
+	log := log.WithFields(log.Fields{
+		"timeout":    timeout,
+		"channelId":  channelId,
+		"amount":     amount,
+		"signature":  BytesToBase64(signature),
+		"isSendBack": sendBack,
+	})
+
+	auth := bind.NewKeyedTransactor(processor.privateKey)
+
+	log.Info("Submitting transaction to claim funds from channel")
+	txn, err := processor.multiPartyEscrow.ChannelClaim(
+		&bind.TransactOpts{
+			From:     common.HexToAddress(processor.address),
+			Signer:   auth.Signer,
+			GasLimit: 1000000,
+		},
+		channelId,
+		amount,
+		signature,
+		sendBack,
+	)
+	if err != nil {
+		log.WithError(err).Error("Error submitting transaction to claim funds from channel")
+		return fmt.Errorf("Error submitting transaction to claim funds from channel: %v", err)
+	}
+
+	log.Info("Transaction sent, waiting for %v till transaction is committed", timeout)
+	endTime := time.Now().Add(timeout)
+	isPending := true
+	for {
+		_, isPending, _ = processor.ethClient.TransactionByHash(context.Background(), txn.Hash())
+		if !isPending {
+			break
+		}
+		if time.Now().After(endTime) {
+			log.Error("Transaction timeout")
+			return fmt.Errorf("Timeout while waiting for blockchain transaction commit")
+		}
+		time.Sleep(time.Second * 1)
+	}
+
+	log.Info("Transaction finished successfully")
+	return nil
+}

--- a/snetd/cmd/claim.go
+++ b/snetd/cmd/claim.go
@@ -55,6 +55,10 @@ func newClaimCommand(cmd *cobra.Command, args []string, components *Components) 
 	if err != nil {
 		return
 	}
+	timeout, err := time.ParseDuration(claimTimeout)
+	if err != nil {
+		return
+	}
 
 	command = &claimCommand{
 		storage:    components.PaymentChannelStorage(),
@@ -62,6 +66,7 @@ func newClaimCommand(cmd *cobra.Command, args []string, components *Components) 
 
 		channelId: channelId,
 		sendBack:  claimSendBack,
+		timeout:   timeout,
 	}
 
 	return

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -20,6 +20,7 @@ var RootCmd = &cobra.Command{
 
 const (
 	ClaimChannelIdFlag = "channel-id"
+	ClaimSendBackFlag  = "send-back"
 )
 
 var (
@@ -41,7 +42,8 @@ var (
 	wireEncoding       = ServeCmd.PersistentFlags().String("wire-encoding", "proto", "message encoding: one of 'proto','json'")
 	pollSleep          = ServeCmd.PersistentFlags().String("poll-sleep", "5s", "blockchain poll sleep time")
 
-	claimChannelId = ClaimCmd.Flags().String(ClaimChannelIdFlag, "", "id of the payment channel to claim money")
+	claimChannelId string
+	claimSendBack  bool
 )
 
 func init() {
@@ -52,7 +54,9 @@ func init() {
 	RootCmd.AddCommand(ServeCmd)
 	RootCmd.AddCommand(ClaimCmd)
 
+	ClaimCmd.Flags().StringVar(&claimChannelId, ClaimChannelIdFlag, "", "id of the payment channel to claim money")
 	ClaimCmd.MarkFlagRequired(ClaimChannelIdFlag)
+	ClaimCmd.Flags().BoolVar(&claimSendBack, ClaimSendBackFlag, false, "send the rest of the channel value back to channel sender")
 
 	vip.BindPFlag(config.AutoSSLDomainKey, serveCmdFlags.Lookup("auto-ssl-domain"))
 	vip.BindPFlag(config.AutoSSLCacheDirKey, serveCmdFlags.Lookup("auto-ssl-cache"))

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -21,6 +21,7 @@ var RootCmd = &cobra.Command{
 const (
 	ClaimChannelIdFlag = "channel-id"
 	ClaimSendBackFlag  = "send-back"
+	ClaimTimeoutFlag   = "timeout"
 )
 
 var (
@@ -44,6 +45,7 @@ var (
 
 	claimChannelId string
 	claimSendBack  bool
+	claimTimeout   string
 )
 
 func init() {
@@ -57,6 +59,7 @@ func init() {
 	ClaimCmd.Flags().StringVar(&claimChannelId, ClaimChannelIdFlag, "", "id of the payment channel to claim money")
 	ClaimCmd.MarkFlagRequired(ClaimChannelIdFlag)
 	ClaimCmd.Flags().BoolVar(&claimSendBack, ClaimSendBackFlag, false, "send the rest of the channel value back to channel sender")
+	ClaimCmd.Flags().StringVar(&claimTimeout, ClaimTimeoutFlag, "5s", "timeout for blockchain transaction")
 
 	vip.BindPFlag(config.AutoSSLDomainKey, serveCmdFlags.Lookup("auto-ssl-domain"))
 	vip.BindPFlag(config.AutoSSLCacheDirKey, serveCmdFlags.Lookup("auto-ssl-cache"))


### PR DESCRIPTION
Work on issue https://github.com/singnet/snet-daemon/issues/72

What is done:
- added code to call MultiPartyEscrow.channelClaim 
- added flags to pass timeout and sendBack parameters

To be done:
- keep list of all payments which were sent to blockchain in etcd
- atomically add payment to etcd and change channel state
- remove payment from etcd when transaction is committed to blockchain