### PR TITLE
Enable etcd storage by default in the config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ const (
 	},
 	"payment_channel_storage_server": {
 		"id": "storage-1",
+		"scheme": "http",
 		"host" : "127.0.0.1",
 		"client_port": 2379,
 		"peer_port": 2380,
@@ -201,6 +202,10 @@ func GetDuration(key string) time.Duration {
 
 func GetBool(key string) bool {
 	return vip.GetBool(key)
+}
+
+func GetDefaultConfJSON() string {
+	return defaultConfigJson
 }
 
 // SubWithDefault returns sub-config by keys including configuration defaults

--- a/config/config.go
+++ b/config/config.go
@@ -77,7 +77,7 @@ const (
 		"hooks": []
 	},
 	"replica_group_id": "0",
-	"payment_channel_storage_type": "memory",
+	"payment_channel_storage_type": "etcd",
 	"payment_channel_storage_client": {
 		"connection_timeout": 5000,
 		"request_timeout": 3000,
@@ -91,7 +91,7 @@ const (
 		"peer_port": 2380,
 		"token": "unique-token",
 		"cluster": "storage-1=http://127.0.0.1:2380",
-		"enabled": false
+		"enabled": true
 	}
 }
 `

--- a/etcddb/etcddb_conf.go
+++ b/etcddb/etcddb_conf.go
@@ -1,6 +1,7 @@
 package etcddb
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/singnet/snet-daemon/config"
@@ -12,10 +13,16 @@ import (
 // is not set in the configuration file
 func GetEtcdClientConf(vip *viper.Viper) (conf *EtcdClientConf, err error) {
 
-	conf = &EtcdClientConf{
-		ConnectionTimeout: 5000,
-		RequestTimeout:    3000,
-		Endpoints:         []string{"http://127.0.0.1:2379"},
+	type DefaultConf struct {
+		PaymentChannelStorageClient *EtcdClientConf `json:"payment_channel_storage_client"`
+	}
+
+	conf = &EtcdClientConf{}
+	defaultConf := &DefaultConf{PaymentChannelStorageClient: conf}
+
+	err = json.Unmarshal([]byte(config.GetDefaultConfJSON()), defaultConf)
+	if err != nil {
+		return
 	}
 
 	if !vip.InConfig(strings.ToLower(config.PaymentChannelStorageClientKey)) {
@@ -49,8 +56,8 @@ type EtcdServerConf struct {
 	ID         string
 	Scheme     string
 	Host       string
-	ClientPort int `mapstructure:"CLIENT_PORT"`
-	PeerPort   int `mapstructure:"PEER_PORT"`
+	ClientPort int `json:"client_port" mapstructure:"CLIENT_PORT"`
+	PeerPort   int `json:"peer_port" mapstructure:"PEER_PORT"`
 	Token      string
 	Cluster    string
 	Enabled    bool
@@ -61,15 +68,16 @@ type EtcdServerConf struct {
 // is not set in the configuration file
 func GetEtcdServerConf(vip *viper.Viper) (conf *EtcdServerConf, err error) {
 
-	conf = &EtcdServerConf{
-		ID:         "storage-1",
-		Scheme:     "http",
-		Host:       "127.0.0.1",
-		ClientPort: 2379,
-		PeerPort:   2380,
-		Token:      "unique-token",
-		Cluster:    "storage-1=http://127.0.0.1:2380",
-		Enabled:    false,
+	type DefaultConf struct {
+		PaymentChannelStorageServer *EtcdServerConf `json:"payment_channel_storage_server"`
+	}
+
+	conf = &EtcdServerConf{}
+	defaultConf := &DefaultConf{PaymentChannelStorageServer: conf}
+
+	err = json.Unmarshal([]byte(config.GetDefaultConfJSON()), defaultConf)
+	if err != nil {
+		return
 	}
 
 	if !vip.InConfig(strings.ToLower(config.PaymentChannelStorageServerKey)) {
@@ -87,7 +95,7 @@ func GetEtcdServerConf(vip *viper.Viper) (conf *EtcdServerConf, err error) {
 // RequestTimeout    - per request timeout
 // Endpoints         - cluster endpoints
 type EtcdClientConf struct {
-	ConnectionTimeout int `mapstructure:"connection_timeout"`
-	RequestTimeout    int `mapstructure:"request_timeout"`
+	ConnectionTimeout int `json:"connection_timeout" mapstructure:"connection_timeout"`
+	RequestTimeout    int `json:"request_timeout" mapstructure:"request_timeout"`
 	Endpoints         []string
 }

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -47,6 +47,8 @@ func GetEtcdServerFromVip(vip *viper.Viper) (server *EtcdServer, err error) {
 
 	conf, err := GetEtcdServerConf(vip)
 
+	log.WithField("PaymentChannelStorageServer", fmt.Sprintf("%+v", conf)).Info()
+
 	if err != nil || conf == nil || !conf.Enabled {
 		return
 	}

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -13,7 +13,7 @@ func TestDefaultEtcdServerConf(t *testing.T) {
 
 	enabled, err := IsEtcdServerEnabled()
 	assert.Nil(t, err)
-	assert.False(t, enabled)
+	assert.True(t, enabled)
 
 	conf, err := GetEtcdServerConf(config.Vip())
 
@@ -27,12 +27,12 @@ func TestDefaultEtcdServerConf(t *testing.T) {
 	assert.Equal(t, 2380, conf.PeerPort)
 	assert.Equal(t, "unique-token", conf.Token)
 	assert.Equal(t, "storage-1=http://127.0.0.1:2380", conf.Cluster)
-	assert.Equal(t, false, conf.Enabled)
+	assert.Equal(t, true, conf.Enabled)
 
 	server, err := GetEtcdServer()
 
 	assert.Nil(t, err)
-	assert.Nil(t, server)
+	assert.NotNil(t, server)
 }
 
 func TestDisabledEtcdServerConf(t *testing.T) {


### PR DESCRIPTION
There are several changes:
* Read etcd client/server default values from the default config file
* Move etcd server starting to components before etcd client initialization.
* Enable etcd server running by default in the config file 

There is separate issue on running etcd client asynchronously #91 