### PR TITLE
Use number of blocks to validate expiration

### DIFF
--- a/blockchain/ethereum_test_util.go
+++ b/blockchain/ethereum_test_util.go
@@ -5,13 +5,13 @@ package blockchain
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
-	"math/big"
-	"time"
 )
 
 type SimulatedEthereumEnvironment struct {
@@ -51,8 +51,8 @@ func (env *SimulatedEthereumEnvironment) MpeDeposit(from *bind.TransactOpts, amo
 	return env
 }
 
-func (env *SimulatedEthereumEnvironment) MpeOpenChannel(from *bind.TransactOpts, to *bind.TransactOpts, amount int64, expiration time.Time, groupId int64) *SimulatedEthereumEnvironment {
-	_, err := env.MultiPartyEscrow.OpenChannel(EstimateGas(from), to.From, big.NewInt(amount), big.NewInt(expiration.Unix()), big.NewInt(groupId))
+func (env *SimulatedEthereumEnvironment) MpeOpenChannel(from *bind.TransactOpts, to *bind.TransactOpts, amount int64, expiration int64, groupId int64) *SimulatedEthereumEnvironment {
+	_, err := env.MultiPartyEscrow.OpenChannel(EstimateGas(from), to.From, big.NewInt(amount), big.NewInt(expiration), big.NewInt(groupId))
 	if err != nil {
 		panic(fmt.Sprintf("Unable to open MPE payment channel: %v", err))
 	}

--- a/escrow/combined_storage.go
+++ b/escrow/combined_storage.go
@@ -2,12 +2,13 @@ package escrow
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/singnet/snet-daemon/blockchain"
 	"github.com/singnet/snet-daemon/config"
-	log "github.com/sirupsen/logrus"
-	"math/big"
-	"time"
 )
 
 type combinedStorage struct {
@@ -84,7 +85,7 @@ func (storage *combinedStorage) getChannelStateFromBlockchain(id *big.Int) (stat
 		Recipient:        channel.Recipient,
 		GroupId:          channel.ReplicaId,
 		FullAmount:       channel.Value,
-		Expiration:       time.Unix(channel.Expiration.Int64(), 0),
+		Expiration:       channel.Expiration,
 		AuthorizedAmount: big.NewInt(0),
 		Signature:        nil,
 	}, true, nil

--- a/escrow/combined_storage_test.go
+++ b/escrow/combined_storage_test.go
@@ -2,13 +2,14 @@ package escrow
 
 import (
 	"crypto/ecdsa"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/singnet/snet-daemon/blockchain"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
-	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/singnet/snet-daemon/blockchain"
 )
 
 type storageTestType struct {
@@ -45,7 +46,7 @@ var storageTest = func() storageTestType {
 			Recipient:        recipientAddress,
 			GroupId:          big.NewInt(0),
 			FullAmount:       big.NewInt(12345),
-			Expiration:       time.Now().Add(time.Hour),
+			Expiration:       big.NewInt(100),
 			AuthorizedAmount: big.NewInt(12300),
 			Signature:        getPaymentSignature(&mpeContractAddress, 42, 3, 12300, senderPrivateKey),
 		},
@@ -96,7 +97,7 @@ func TestCombinedStorageGetAlreadyInStorage(t *testing.T) {
 		Recipient:        storageTest.recipientAddress,
 		GroupId:          big.NewInt(0),
 		FullAmount:       big.NewInt(12345),
-		Expiration:       time.Now().Add(time.Hour),
+		Expiration:       big.NewInt(100),
 		AuthorizedAmount: big.NewInt(12300),
 		Signature:        getPaymentSignature(&storageTest.mpeContractAddress, 42, 3, 12300, storageTest.senderPrivateKey),
 	}
@@ -114,7 +115,7 @@ func TestCombinedStorageGetAlreadyInStorage(t *testing.T) {
 }
 
 func TestCombinedStorageGetReadFromBlockchain(t *testing.T) {
-	expiration := time.Unix(time.Now().Add(time.Hour).Unix(), 0)
+	expiration := int64(100)
 	expectedChannel := &PaymentChannelData{
 		Nonce:            big.NewInt(0),
 		State:            Open,
@@ -122,7 +123,7 @@ func TestCombinedStorageGetReadFromBlockchain(t *testing.T) {
 		Recipient:        storageTest.recipientAddress,
 		GroupId:          big.NewInt(0),
 		FullAmount:       big.NewInt(12345),
-		Expiration:       expiration,
+		Expiration:       big.NewInt(expiration),
 		AuthorizedAmount: big.NewInt(0),
 		Signature:        nil,
 	}

--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -165,8 +165,13 @@ func (storage *paymentChannelStorageImpl) CompareAndSwap(key *PaymentChannelKey,
 	return storage.AtomicStorage.CompareAndSwap(key.String(), string(prevData), string(newData))
 }
 
-type EscrowBlockchainFunctions interface {
+// EscrowBlockchainApi is an interface implemented by blockchain.Processor to
+// provide blockchain operations related to MultiPartyEscrow contract
+// processing.
+type EscrowBlockchainApi interface {
+	// EscrowContractAddress returns address of the MultiPartyEscrowContract
 	EscrowContractAddress() common.Address
+	// CurrentBlock returns current Ethereum blockchain block number
 	CurrentBlock() (currentBlock *big.Int, err error)
 }
 
@@ -174,7 +179,7 @@ type EscrowBlockchainFunctions interface {
 type escrowPaymentHandler struct {
 	storage         PaymentChannelStorage
 	incomeValidator IncomeValidator
-	blockchain      EscrowBlockchainFunctions
+	blockchain      EscrowBlockchainApi
 }
 
 // NewEscrowPaymentHandler returns instance of handler.PaymentHandler to validate


### PR DESCRIPTION
Work on issue https://github.com/singnet/snet-daemon/issues/72

What is done:
- current ethereum block number is used instead of expiration timestamp