### PR TITLE
Define etcd server timeouts in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -206,10 +205,6 @@ func GetBool(key string) bool {
 	return vip.GetBool(key)
 }
 
-func GetDefaultConfJSON() string {
-	return defaultConfigJson
-}
-
 // SubWithDefault returns sub-config by keys including configuration defaults
 // values. It returns nil if no such key. It is analog of the viper.Sub()
 // function. This is workaround for the issue
@@ -227,27 +222,6 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	}
 
 	return sub
-}
-
-// DefaultVip returns viper config that contains only values
-// from the defaultConfigJson string.
-// This is a workaround for the SubWithDefault(...) method
-// which returns only default key/value pairs for keys
-// which has been defined in a user config.
-func DefaultVip() (defaultVip *viper.Viper, err error) {
-
-	defaultVip = viper.New()
-	var defaultMap map[string]interface{}
-	err = json.Unmarshal([]byte(defaultConfigJson), &defaultMap)
-	if err != nil {
-		return
-	}
-
-	for key, value := range defaultMap {
-		defaultVip.Set(key, value)
-	}
-
-	return
 }
 
 var hiddenKeys = map[string]bool{

--- a/config/config.go
+++ b/config/config.go
@@ -80,8 +80,8 @@ const (
 	"replica_group_id": "0",
 	"payment_channel_storage_type": "etcd",
 	"payment_channel_storage_client": {
-		"connection_timeout": 5000,
-		"request_timeout": 3000,
+		"connection_timeout": "5s",
+		"request_timeout": "3s",
 		"endpoints": ["http://127.0.0.1:2379"]
 	},
 	"payment_channel_storage_server": {
@@ -92,6 +92,7 @@ const (
 		"peer_port": 2380,
 		"token": "unique-token",
 		"cluster": "storage-1=http://127.0.0.1:2380",
+		"startup_timeout": "1m",
 		"enabled": true
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -225,6 +226,27 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	}
 
 	return sub
+}
+
+// DefaultVip returns viper config that contains only values
+// from the defaultConfigJson string.
+// This is a workaround for the SubWithDefault(...) method
+// which returns only default key/value pairs for keys
+// which has been defined in a user config.
+func DefaultVip() (defaultVip *viper.Viper, err error) {
+
+	defaultVip = viper.New()
+	var defaultMap map[string]interface{}
+	err = json.Unmarshal([]byte(defaultConfigJson), &defaultMap)
+	if err != nil {
+		return
+	}
+
+	for key, value := range defaultMap {
+		defaultVip.Set(key, value)
+	}
+
+	return
 }
 
 var hiddenKeys = map[string]bool{

--- a/etcddb/etcddb_client.go
+++ b/etcddb/etcddb_client.go
@@ -13,14 +13,6 @@ import (
 	"github.com/coreos/etcd/clientv3/concurrency"
 )
 
-const (
-	// DefaultConnectionTimeout default connection timeout in milliseconds
-	DefaultConnectionTimeout = 5000
-
-	// DefaultRequestTimeout default request timeout in milliseconds
-	DefaultRequestTimeout = 3000
-)
-
 // EtcdClient struct has some useful methods to wolrk with etcd client
 type EtcdClient struct {
 	timeout time.Duration
@@ -43,20 +35,16 @@ func NewEtcdClientFromVip(vip *viper.Viper) (client *EtcdClient, err error) {
 
 	log.WithField("PaymentChannelStorageClient", fmt.Sprintf("%+v", conf)).Info()
 
-	connectionTimeout := time.Duration(conf.ConnectionTimeout) * time.Millisecond
-
 	etcdv3, err := clientv3.New(clientv3.Config{
 		Endpoints:   conf.Endpoints,
-		DialTimeout: connectionTimeout,
+		DialTimeout: conf.ConnectionTimeout,
 	})
 
 	if err != nil {
 		return
 	}
 
-	requestTimeout := time.Duration(conf.RequestTimeout) * time.Millisecond
-	client = &EtcdClient{timeout: requestTimeout, etcdv3: etcdv3}
-
+	client = &EtcdClient{timeout: conf.RequestTimeout, etcdv3: etcdv3}
 	return
 }
 

--- a/etcddb/etcddb_conf.go
+++ b/etcddb/etcddb_conf.go
@@ -2,10 +2,21 @@ package etcddb
 
 import (
 	"strings"
+	"time"
 
 	"github.com/singnet/snet-daemon/config"
 	"github.com/spf13/viper"
 )
+
+// EtcdClientConf config
+// ConnectionTimeout - timeout for failing to establish a connection
+// RequestTimeout    - per request timeout
+// Endpoints         - cluster endpoints
+type EtcdClientConf struct {
+	ConnectionTimeout time.Duration `json:"connection_timeout" mapstructure:"connection_timeout"`
+	RequestTimeout    time.Duration `json:"request_timeout" mapstructure:"request_timeout"`
+	Endpoints         []string
+}
 
 // GetEtcdClientConf gets EtcdServerConf from viper
 // The DefaultEtcdClientConf is used in case the PAYMENT_CHANNEL_STORAGE_CLIENT field
@@ -49,18 +60,20 @@ func normalizeDefaultConf(conf string) string {
 //         cluster IDs and member IDs for the clusters even if they otherwise have
 //         the exact same configuration. This can protect etcd from
 //         cross-cluster-interaction, which might corrupt the clusters.
+// StartupTimeout - time to wait the etcd server successfully started
 // Enabled - enable running embedded etcd server
 // For more details see etcd Clustering Guide link:
 // https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/clustering.md
 type EtcdServerConf struct {
-	ID         string
-	Scheme     string
-	Host       string
-	ClientPort int `json:"client_port" mapstructure:"CLIENT_PORT"`
-	PeerPort   int `json:"peer_port" mapstructure:"PEER_PORT"`
-	Token      string
-	Cluster    string
-	Enabled    bool
+	ID             string
+	Scheme         string
+	Host           string
+	ClientPort     int `json:"client_port" mapstructure:"CLIENT_PORT"`
+	PeerPort       int `json:"peer_port" mapstructure:"PEER_PORT"`
+	Token          string
+	Cluster        string
+	StartupTimeout time.Duration `json:"startup_timeout" mapstructure:"startup_timeout"`
+	Enabled        bool
 }
 
 // GetEtcdServerConf gets EtcdServerConf from viper
@@ -89,14 +102,4 @@ func GetEtcdServerConf(vip *viper.Viper) (conf *EtcdServerConf, err error) {
 
 	err = vip.UnmarshalKey(key, conf)
 	return
-}
-
-// EtcdClientConf config
-// ConnectionTimeout - timeout for failing to establish a connection
-// RequestTimeout    - per request timeout
-// Endpoints         - cluster endpoints
-type EtcdClientConf struct {
-	ConnectionTimeout int `json:"connection_timeout" mapstructure:"connection_timeout"`
-	RequestTimeout    int `json:"request_timeout" mapstructure:"request_timeout"`
-	Endpoints         []string
 }

--- a/etcddb/etcddb_conf.go
+++ b/etcddb/etcddb_conf.go
@@ -25,22 +25,8 @@ func GetEtcdClientConf(vip *viper.Viper) (conf *EtcdClientConf, err error) {
 
 	key := config.PaymentChannelStorageClientKey
 	conf = &EtcdClientConf{}
-
-	defaultVip, err := config.DefaultVip()
-	if err != nil {
-		return
-	}
-
-	err = defaultVip.UnmarshalKey(key, conf)
-	if err != nil {
-		return
-	}
-
-	if !vip.InConfig(strings.ToLower(key)) {
-		return
-	}
-
-	err = vip.UnmarshalKey(key, conf)
+	subVip := config.SubWithDefault(vip, key)
+	err = subVip.Unmarshal(conf)
 	return
 }
 
@@ -84,12 +70,8 @@ func GetEtcdServerConf(vip *viper.Viper) (conf *EtcdServerConf, err error) {
 	key := config.PaymentChannelStorageServerKey
 	conf = &EtcdServerConf{}
 
-	defaultVip, err := config.DefaultVip()
-	if err != nil {
-		return
-	}
-
-	err = defaultVip.UnmarshalKey(key, conf)
+	subVip := config.SubWithDefault(vip, key)
+	err = subVip.Unmarshal(conf)
 	if err != nil {
 		return
 	}

--- a/etcddb/etcddb_conf.go
+++ b/etcddb/etcddb_conf.go
@@ -1,7 +1,6 @@
 package etcddb
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/singnet/snet-daemon/config"
@@ -13,23 +12,24 @@ import (
 // is not set in the configuration file
 func GetEtcdClientConf(vip *viper.Viper) (conf *EtcdClientConf, err error) {
 
-	type DefaultConf struct {
-		PaymentChannelStorageClient *EtcdClientConf `json:"payment_channel_storage_client"`
-	}
-
+	key := config.PaymentChannelStorageClientKey
 	conf = &EtcdClientConf{}
-	defaultConf := &DefaultConf{PaymentChannelStorageClient: conf}
 
-	err = json.Unmarshal([]byte(config.GetDefaultConfJSON()), defaultConf)
+	defaultVip, err := config.DefaultVip()
 	if err != nil {
 		return
 	}
 
-	if !vip.InConfig(strings.ToLower(config.PaymentChannelStorageClientKey)) {
+	err = defaultVip.UnmarshalKey(key, conf)
+	if err != nil {
 		return
 	}
 
-	err = vip.UnmarshalKey(config.PaymentChannelStorageClientKey, conf)
+	if !vip.InConfig(strings.ToLower(key)) {
+		return
+	}
+
+	err = vip.UnmarshalKey(key, conf)
 	return
 }
 
@@ -68,25 +68,26 @@ type EtcdServerConf struct {
 // is not set in the configuration file
 func GetEtcdServerConf(vip *viper.Viper) (conf *EtcdServerConf, err error) {
 
-	type DefaultConf struct {
-		PaymentChannelStorageServer *EtcdServerConf `json:"payment_channel_storage_server"`
-	}
-
+	key := config.PaymentChannelStorageServerKey
 	conf = &EtcdServerConf{}
-	defaultConf := &DefaultConf{PaymentChannelStorageServer: conf}
 
-	err = json.Unmarshal([]byte(config.GetDefaultConfJSON()), defaultConf)
+	defaultVip, err := config.DefaultVip()
 	if err != nil {
 		return
 	}
 
-	if !vip.InConfig(strings.ToLower(config.PaymentChannelStorageServerKey)) {
+	err = defaultVip.UnmarshalKey(key, conf)
+	if err != nil {
+		return
+	}
+
+	if !vip.InConfig(strings.ToLower(key)) {
 		return
 	}
 
 	conf.Enabled = true
 
-	err = vip.UnmarshalKey(config.PaymentChannelStorageServerKey, conf)
+	err = vip.UnmarshalKey(key, conf)
 	return
 }
 

--- a/etcddb/etcddb_conf_test.go
+++ b/etcddb/etcddb_conf_test.go
@@ -1,0 +1,164 @@
+package etcddb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/singnet/snet-daemon/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultEtcdClientConf(t *testing.T) {
+
+	conf, err := GetEtcdClientConf(config.Vip())
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+
+	assert.Equal(t, 5*time.Second, conf.ConnectionTimeout)
+	assert.Equal(t, 3*time.Second, conf.RequestTimeout)
+	assert.Equal(t, []string{"http://127.0.0.1:2379"}, conf.Endpoints)
+}
+
+func TestCustomEtcdClientConf(t *testing.T) {
+
+	const confJSON = `
+	{
+		"payment_channel_storage_client": {
+			"connection_timeout": "15s",
+			"request_timeout": "5s",
+			"endpoints": ["http://127.0.0.1:2479"]
+		}
+	}`
+
+	vip := readConfig(t, confJSON)
+
+	conf, err := GetEtcdClientConf(vip)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+	assert.Equal(t, 15*time.Second, conf.ConnectionTimeout)
+	assert.Equal(t, 5*time.Second, conf.RequestTimeout)
+	assert.Equal(t, []string{"http://127.0.0.1:2479"}, conf.Endpoints)
+}
+func TestCustomEtcdClientConfWithDefault(t *testing.T) {
+
+	const confJSON = `
+	{
+		"payment_channel_storage_client": {
+			"connection_timeout": "15s"
+		}
+	}`
+
+	vip := readConfig(t, confJSON)
+
+	conf, err := GetEtcdClientConf(vip)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+	assert.Equal(t, 15*time.Second, conf.ConnectionTimeout)
+	assert.Equal(t, 3*time.Second, conf.RequestTimeout)
+	assert.Equal(t, []string{"http://127.0.0.1:2379"}, conf.Endpoints)
+}
+
+func TestDefaultEtcdServerConf(t *testing.T) {
+
+	enabled, err := IsEtcdServerEnabled()
+	assert.Nil(t, err)
+	assert.True(t, enabled)
+
+	conf, err := GetEtcdServerConf(config.Vip())
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+
+	assert.Equal(t, "storage-1", conf.ID)
+	assert.Equal(t, "http", conf.Scheme)
+	assert.Equal(t, "127.0.0.1", conf.Host)
+	assert.Equal(t, 2379, conf.ClientPort)
+	assert.Equal(t, 2380, conf.PeerPort)
+	assert.Equal(t, "unique-token", conf.Token)
+	assert.Equal(t, "storage-1=http://127.0.0.1:2380", conf.Cluster)
+	assert.Equal(t, time.Minute, conf.StartupTimeout)
+	assert.Equal(t, true, conf.Enabled)
+
+	server, err := GetEtcdServer()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, server)
+}
+
+func TestDisabledEtcdServerConf(t *testing.T) {
+
+	const confJSON = `
+		{
+			"payment_channel_storage_server": {
+				"enabled": false
+			}
+		}`
+
+	vip := readConfig(t, confJSON)
+	enabled, err := IsEtcdServerEnabledInVip(vip)
+	assert.Nil(t, err)
+	assert.False(t, enabled)
+
+	server, err := GetEtcdServerFromVip(vip)
+
+	assert.Nil(t, err)
+	assert.Nil(t, server)
+}
+
+func TestEnabledEtcdServerConf(t *testing.T) {
+
+	const confJSON = `
+	{
+		"payment_channel_storage_server": {
+			"id": "storage-1",
+			"host" : "127.0.0.1",
+			"client_port": 2379,
+			"peer_port": 2380,
+			"token": "unique-token",
+			"cluster": "storage-1=http://127.0.0.1:2380",
+			"startup_timeout": "15s",
+			"enabled": true
+		}
+	}`
+
+	vip := readConfig(t, confJSON)
+
+	enabled, err := IsEtcdServerEnabledInVip(vip)
+	assert.Nil(t, err)
+	assert.True(t, enabled)
+
+	conf, err := GetEtcdServerConf(vip)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+
+	assert.Equal(t, "storage-1", conf.ID)
+	assert.Equal(t, "http", conf.Scheme)
+	assert.Equal(t, "127.0.0.1", conf.Host)
+	assert.Equal(t, 2379, conf.ClientPort)
+	assert.Equal(t, 2380, conf.PeerPort)
+	assert.Equal(t, "unique-token", conf.Token)
+	assert.Equal(t, 15*time.Second, conf.StartupTimeout)
+	assert.Equal(t, true, conf.Enabled)
+
+	server, err := GetEtcdServerFromVip(vip)
+	assert.Nil(t, err)
+	assert.NotNil(t, server)
+
+	err = server.Start()
+	assert.Nil(t, err)
+	defer server.Close()
+}
+
+func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {
+	vip = viper.New()
+	config.SetDefaultFromConfig(vip, config.Vip())
+
+	err := config.ReadConfigFromJsonString(vip, configJSON)
+	assert.Nil(t, err)
+	return
+}

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -88,7 +88,7 @@ func startEtcdServer(conf *EtcdServerConf) (etcd *embed.Etcd, err error) {
 
 	select {
 	case <-etcd.Server.ReadyNotify():
-	case <-time.After(60 * time.Second):
+	case <-time.After(conf.StartupTimeout):
 		etcd.Server.Stop()
 		return nil, errors.New("etcd server took too long to start: " + conf.ID)
 	}

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -373,7 +373,9 @@ func getKeyValuesWithPrefix(keyPrefix string, valuePrefix string, count int) (ke
 }
 
 func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {
-	vip = config.Vip()
+	vip = viper.New()
+	config.SetDefaultFromConfig(vip, config.Vip())
+
 	err := config.ReadConfigFromJsonString(vip, configJSON)
 	assert.Nil(t, err)
 	return

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -3,158 +3,11 @@ package etcddb
 import (
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/singnet/snet-daemon/config"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
 // TODO: initialize client and server only once to make test faster
-
-func TestDefaultEtcdServerConf(t *testing.T) {
-
-	enabled, err := IsEtcdServerEnabled()
-	assert.Nil(t, err)
-	assert.True(t, enabled)
-
-	conf, err := GetEtcdServerConf(config.Vip())
-
-	assert.Nil(t, err)
-	assert.NotNil(t, conf)
-
-	assert.Equal(t, "storage-1", conf.ID)
-	assert.Equal(t, "http", conf.Scheme)
-	assert.Equal(t, "127.0.0.1", conf.Host)
-	assert.Equal(t, 2379, conf.ClientPort)
-	assert.Equal(t, 2380, conf.PeerPort)
-	assert.Equal(t, "unique-token", conf.Token)
-	assert.Equal(t, "storage-1=http://127.0.0.1:2380", conf.Cluster)
-	assert.Equal(t, time.Minute, conf.StartupTimeout)
-	assert.Equal(t, true, conf.Enabled)
-
-	server, err := GetEtcdServer()
-
-	assert.Nil(t, err)
-	assert.NotNil(t, server)
-}
-
-func TestDisabledEtcdServerConf(t *testing.T) {
-
-	const confJSON = `
-		{
-			"payment_channel_storage_server": {
-				"enabled": false
-			}
-		}`
-
-	vip := readConfig(t, confJSON)
-	enabled, err := IsEtcdServerEnabledInVip(vip)
-	assert.Nil(t, err)
-	assert.False(t, enabled)
-
-	server, err := GetEtcdServerFromVip(vip)
-
-	assert.Nil(t, err)
-	assert.Nil(t, server)
-}
-
-func TestEnabledEtcdServerConf(t *testing.T) {
-
-	const confJSON = `
-	{
-		"payment_channel_storage_server": {
-			"id": "storage-1",
-			"host" : "127.0.0.1",
-			"client_port": 2379,
-			"peer_port": 2380,
-			"token": "unique-token",
-			"cluster": "storage-1=http://127.0.0.1:2380",
-			"startup_timeout": "15s",
-			"enabled": true
-		}
-	}`
-
-	vip := readConfig(t, confJSON)
-
-	enabled, err := IsEtcdServerEnabledInVip(vip)
-	assert.Nil(t, err)
-	assert.True(t, enabled)
-
-	conf, err := GetEtcdServerConf(vip)
-
-	assert.Nil(t, err)
-	assert.NotNil(t, conf)
-
-	assert.Equal(t, "storage-1", conf.ID)
-	assert.Equal(t, "127.0.0.1", conf.Host)
-	assert.Equal(t, 2379, conf.ClientPort)
-	assert.Equal(t, 2380, conf.PeerPort)
-	assert.Equal(t, "unique-token", conf.Token)
-	assert.Equal(t, 15*time.Second, conf.StartupTimeout)
-	assert.Equal(t, true, conf.Enabled)
-
-	server, err := GetEtcdServerFromVip(vip)
-	assert.Nil(t, err)
-	assert.NotNil(t, server)
-
-	err = server.Start()
-	assert.Nil(t, err)
-	defer server.Close()
-}
-
-func TestDefaultEtcdClientConf(t *testing.T) {
-
-	conf, err := GetEtcdClientConf(config.Vip())
-
-	assert.Nil(t, err)
-	assert.NotNil(t, conf)
-
-	assert.Equal(t, 5*time.Second, conf.ConnectionTimeout)
-	assert.Equal(t, 3*time.Second, conf.RequestTimeout)
-	assert.Equal(t, []string{"http://127.0.0.1:2379"}, conf.Endpoints)
-}
-
-func TestEtcdClientConf(t *testing.T) {
-
-	const confJSON = `
-	{
-		"payment_channel_storage_client": {
-			"connection_timeout": "15s",
-			"request_timeout": "5s",
-			"endpoints": ["http://127.0.0.1:2479"]
-		}
-	}`
-
-	vip := readConfig(t, confJSON)
-
-	conf, err := GetEtcdClientConf(vip)
-
-	assert.Nil(t, err)
-	assert.NotNil(t, conf)
-	assert.Equal(t, 15*time.Second, conf.ConnectionTimeout)
-	assert.Equal(t, 5*time.Second, conf.RequestTimeout)
-	assert.Equal(t, []string{"http://127.0.0.1:2479"}, conf.Endpoints)
-}
-func TestEtcdClientConfWithDefault(t *testing.T) {
-
-	const confJSON = `
-	{
-		"payment_channel_storage_client": {
-			"connection_timeout": "15s"
-		}
-	}`
-
-	vip := readConfig(t, confJSON)
-
-	conf, err := GetEtcdClientConf(vip)
-
-	assert.Nil(t, err)
-	assert.NotNil(t, conf)
-	assert.Equal(t, 15*time.Second, conf.ConnectionTimeout)
-	assert.Equal(t, 3*time.Second, conf.RequestTimeout)
-	assert.Equal(t, []string{"http://127.0.0.1:2379"}, conf.Endpoints)
-}
 
 func TestEtcdPutGet(t *testing.T) {
 
@@ -369,14 +222,5 @@ func getKeyValuesWithPrefix(keyPrefix string, valuePrefix string, count int) (ke
 		keyValue := keyValue{key, value}
 		keyValues = append(keyValues, keyValue)
 	}
-	return
-}
-
-func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {
-	vip = viper.New()
-	config.SetDefaultFromConfig(vip, config.Vip())
-
-	err := config.ReadConfigFromJsonString(vip, configJSON)
-	assert.Nil(t, err)
 	return
 }

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -14,8 +14,8 @@ func TestEtcdPutGet(t *testing.T) {
 	const confJSON = `
 	{
 		"payment_channel_storage_client": {
-			"connection_timeout": 5000,
-			"request_timeout": 3000,
+			"connection_timeout": "5s",
+			"request_timeout": "3s",
 			"endpoints": ["http://127.0.0.1:2379"]
 		},
 

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -136,6 +136,25 @@ func TestEtcdClientConf(t *testing.T) {
 	assert.Equal(t, 5*time.Second, conf.RequestTimeout)
 	assert.Equal(t, []string{"http://127.0.0.1:2479"}, conf.Endpoints)
 }
+func TestEtcdClientConfWithDefault(t *testing.T) {
+
+	const confJSON = `
+	{
+		"payment_channel_storage_client": {
+			"connection_timeout": "15s"
+		}
+	}`
+
+	vip := readConfig(t, confJSON)
+
+	conf, err := GetEtcdClientConf(vip)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+	assert.Equal(t, 15*time.Second, conf.ConnectionTimeout)
+	assert.Equal(t, 3*time.Second, conf.RequestTimeout)
+	assert.Equal(t, []string{"http://127.0.0.1:2379"}, conf.Endpoints)
+}
 
 func TestEtcdPutGet(t *testing.T) {
 
@@ -354,7 +373,7 @@ func getKeyValuesWithPrefix(keyPrefix string, valuePrefix string, count int) (ke
 }
 
 func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {
-	vip = viper.New()
+	vip = config.Vip()
 	err := config.ReadConfigFromJsonString(vip, configJSON)
 	assert.Nil(t, err)
 	return

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -3,6 +3,7 @@ package etcddb
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/singnet/snet-daemon/config"
 	"github.com/spf13/viper"
@@ -29,6 +30,7 @@ func TestDefaultEtcdServerConf(t *testing.T) {
 	assert.Equal(t, 2380, conf.PeerPort)
 	assert.Equal(t, "unique-token", conf.Token)
 	assert.Equal(t, "storage-1=http://127.0.0.1:2380", conf.Cluster)
+	assert.Equal(t, time.Minute, conf.StartupTimeout)
 	assert.Equal(t, true, conf.Enabled)
 
 	server, err := GetEtcdServer()
@@ -68,6 +70,7 @@ func TestEnabledEtcdServerConf(t *testing.T) {
 			"peer_port": 2380,
 			"token": "unique-token",
 			"cluster": "storage-1=http://127.0.0.1:2380",
+			"startup_timeout": "15s",
 			"enabled": true
 		}
 	}`
@@ -88,6 +91,7 @@ func TestEnabledEtcdServerConf(t *testing.T) {
 	assert.Equal(t, 2379, conf.ClientPort)
 	assert.Equal(t, 2380, conf.PeerPort)
 	assert.Equal(t, "unique-token", conf.Token)
+	assert.Equal(t, 15*time.Second, conf.StartupTimeout)
 	assert.Equal(t, true, conf.Enabled)
 
 	server, err := GetEtcdServerFromVip(vip)
@@ -106,8 +110,8 @@ func TestDefaultEtcdClientConf(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, conf)
 
-	assert.Equal(t, 5000, conf.ConnectionTimeout)
-	assert.Equal(t, 3000, conf.RequestTimeout)
+	assert.Equal(t, 5*time.Second, conf.ConnectionTimeout)
+	assert.Equal(t, 3*time.Second, conf.RequestTimeout)
 	assert.Equal(t, []string{"http://127.0.0.1:2379"}, conf.Endpoints)
 }
 
@@ -116,8 +120,8 @@ func TestEtcdClientConf(t *testing.T) {
 	const confJSON = `
 	{
 		"payment_channel_storage_client": {
-			"connection_timeout": 15000,
-			"request_timeout": 5000,
+			"connection_timeout": "15s",
+			"request_timeout": "5s",
 			"endpoints": ["http://127.0.0.1:2479"]
 		}
 	}`
@@ -128,8 +132,8 @@ func TestEtcdClientConf(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, conf)
-	assert.Equal(t, 15000, conf.ConnectionTimeout)
-	assert.Equal(t, 5000, conf.RequestTimeout)
+	assert.Equal(t, 15*time.Second, conf.ConnectionTimeout)
+	assert.Equal(t, 5*time.Second, conf.RequestTimeout)
 	assert.Equal(t, []string{"http://127.0.0.1:2479"}, conf.Endpoints)
 }
 


### PR DESCRIPTION
The fix allows to configure  etcd client/server timeouts in a config file using time units.
SubWithDefault()  is used to load Viper config with default values.