### PR TITLE
Clean etcd tests work directories

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,7 @@ const (
 		"token": "unique-token",
 		"cluster": "storage-1=http://127.0.0.1:2380",
 		"startup_timeout": "1m",
+		"data_dir": "storage-data-dir-1.etcd",
 		"enabled": true
 	}
 }

--- a/etcddb/etcddb_conf.go
+++ b/etcddb/etcddb_conf.go
@@ -60,6 +60,7 @@ type EtcdServerConf struct {
 	Cluster        string
 	StartupTimeout time.Duration `json:"startup_timeout" mapstructure:"startup_timeout"`
 	Enabled        bool
+	DataDir        string `json:"data_dir" mapstructure:"DATA_DIR"`
 }
 
 // GetEtcdServerConf gets EtcdServerConf from viper

--- a/etcddb/etcddb_conf_test.go
+++ b/etcddb/etcddb_conf_test.go
@@ -81,6 +81,7 @@ func TestDefaultEtcdServerConf(t *testing.T) {
 	assert.Equal(t, "unique-token", conf.Token)
 	assert.Equal(t, "storage-1=http://127.0.0.1:2380", conf.Cluster)
 	assert.Equal(t, time.Minute, conf.StartupTimeout)
+	assert.Equal(t, "storage-data-dir-1.etcd", conf.DataDir)
 	assert.Equal(t, true, conf.Enabled)
 
 	server, err := GetEtcdServer()
@@ -121,6 +122,7 @@ func TestEnabledEtcdServerConf(t *testing.T) {
 			"token": "unique-token",
 			"cluster": "storage-1=http://127.0.0.1:2380",
 			"startup_timeout": "15s",
+			"data_dir": "custom-storage-data-dir-1.etcd",
 			"enabled": true
 		}
 	}`
@@ -143,6 +145,7 @@ func TestEnabledEtcdServerConf(t *testing.T) {
 	assert.Equal(t, 2380, conf.PeerPort)
 	assert.Equal(t, "unique-token", conf.Token)
 	assert.Equal(t, 15*time.Second, conf.StartupTimeout)
+	assert.Equal(t, "custom-storage-data-dir-1.etcd", conf.DataDir)
 	assert.Equal(t, true, conf.Enabled)
 
 	server, err := GetEtcdServerFromVip(vip)
@@ -152,6 +155,7 @@ func TestEnabledEtcdServerConf(t *testing.T) {
 	err = server.Start()
 	assert.Nil(t, err)
 	defer server.Close()
+	defer removeWorkDir(t, conf.DataDir)
 }
 
 func readConfig(t *testing.T, configJSON string) (vip *viper.Viper) {

--- a/etcddb/etcddb_server.go
+++ b/etcddb/etcddb_server.go
@@ -114,7 +114,7 @@ func getEtcdConf(conf *EtcdServerConf) *embed.Config {
 
 	etcdConf := embed.NewConfig()
 	etcdConf.Name = conf.ID
-	etcdConf.Dir = conf.ID + ".etcd"
+	etcdConf.Dir = conf.DataDir
 
 	// --listen-client-urls
 	etcdConf.LCUrls = []url.URL{*clientURL}

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -2,6 +2,9 @@ package etcddb
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/smartystreets/gunit"
@@ -65,6 +68,8 @@ func (fixture *EtcdTestFixture) SetupStuff() {
 
 func (fixture *EtcdTestFixture) TeardownStuff() {
 
+	defer removeWorkDirs()
+
 	if fixture.client != nil {
 		fixture.client.Close()
 	}
@@ -72,6 +77,7 @@ func (fixture *EtcdTestFixture) TeardownStuff() {
 	if fixture.server != nil {
 		fixture.server.Close()
 	}
+
 }
 
 func (fixture *EtcdTestFixture) TestEtcdPutGet() {
@@ -213,4 +219,24 @@ func getKeyValuesWithPrefix(keyPrefix string, valuePrefix string, count int) (ke
 		keyValues = append(keyValues, keyValue)
 	}
 	return
+}
+
+func removeWorkDirs() {
+
+	t := testingEtcdDB
+
+	dir, err := os.Getwd()
+	assert.Nil(t, err)
+
+	files, err := ioutil.ReadDir(dir)
+	assert.Nil(t, err)
+
+	for _, f := range files {
+		name := f.Name()
+		if f.IsDir() && strings.HasPrefix(name, "storage-") {
+			fmt.Println(name)
+			err = os.RemoveAll(name)
+			assert.Nil(t, err)
+		}
+	}
 }


### PR DESCRIPTION
* **data_dir** property is added to the EtcdServer configuration file
* gunit is used in tests to run setup and teardown methods
* test data dirs are cleaned