### PR TITLE
Etcd client mutex implementation

### DIFF
--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -214,7 +214,6 @@ func (suite *EtcdTestSuite) TestEtcdMutex() {
 	}
 
 	t := suite.T()
-	client := suite.client
 
 	pair := &Pair{a: 0, b: 0}
 	lockKey := "key-mutex"
@@ -227,9 +226,12 @@ func (suite *EtcdTestSuite) TestEtcdMutex() {
 
 	runWithLock := func(value int) {
 
+		client, err := NewEtcdClient()
+		assert.Nil(t, err)
+		defer client.Close()
+
 		mutex, err := client.NewMutex(lockKey)
 		assert.Nil(t, err)
-		defer mutex.Close()
 		defer mutex.Unlock(context.Background())
 		defer end.Done()
 		start.Done()


### PR DESCRIPTION
The current fix proposes a simple API  to use mutex-es in Etcd client
- The etcd session is created only once and is kept in etcd client
- Each mutex is created for the given key
- Context is used to cancel an etcd lock or to stop it by timeout
- Mutex-es for the same session do not block each other. Only different clients with different sessions are blocked if a mutex is used for the same key. 