### PR TITLE
Add etcd Transcation method

### DIFF
--- a/etcddb/etcddb_client.go
+++ b/etcddb/etcddb_client.go
@@ -164,14 +164,14 @@ type EtcdKeyValue struct {
 // CompareAndSwap uses CAS operation to set a value
 func (client *EtcdClient) CompareAndSwap(key string, prevValue string, newValue string) (ok bool, err error) {
 
-	return client.ExtendedCompareAndSwap(
+	return client.Transaction(
 		[]EtcdKeyValue{EtcdKeyValue{key: key, value: prevValue}},
 		[]EtcdKeyValue{EtcdKeyValue{key: key, value: newValue}},
 	)
 }
 
-// ExtendedCompareAndSwap uses CAS operation to compare and set multiple key values
-func (client *EtcdClient) ExtendedCompareAndSwap(compare []EtcdKeyValue, swap []EtcdKeyValue) (ok bool, err error) {
+// Transaction uses CAS operation to compare and set multiple key values
+func (client *EtcdClient) Transaction(compare []EtcdKeyValue, swap []EtcdKeyValue) (ok bool, err error) {
 
 	log := log.WithField("func", "CompareAndSwap").WithField("client", client)
 

--- a/etcddb/etcddb_client.go
+++ b/etcddb/etcddb_client.go
@@ -3,6 +3,7 @@ package etcddb
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/singnet/snet-daemon/config"
@@ -154,22 +155,50 @@ func (client *EtcdClient) Delete(key string) error {
 	return err
 }
 
+// EtcdKeyValue contains key and value
+type EtcdKeyValue struct {
+	key   string
+	value string
+}
+
 // CompareAndSwap uses CAS operation to set a value
 func (client *EtcdClient) CompareAndSwap(key string, prevValue string, newValue string) (ok bool, err error) {
-	log := log.WithField("func", "CompareAndSwap").WithField("key", key).WithField("client", client)
+
+	return client.ExtendedCompareAndSwap(
+		[]EtcdKeyValue{EtcdKeyValue{key: key, value: prevValue}},
+		[]EtcdKeyValue{EtcdKeyValue{key: key, value: newValue}},
+	)
+}
+
+// ExtendedCompareAndSwap uses CAS operation to compare and set multiple key values
+func (client *EtcdClient) ExtendedCompareAndSwap(compare []EtcdKeyValue, swap []EtcdKeyValue) (ok bool, err error) {
+
+	log := log.WithField("func", "CompareAndSwap").WithField("client", client)
 
 	etcdv3 := client.etcdv3
 	ctx, cancel := context.WithTimeout(context.Background(), client.timeout)
 	defer cancel()
 
-	response, err := etcdv3.KV.Txn(ctx).If(
-		clientv3.Compare(clientv3.Value(key), "=", prevValue),
-	).Then(
-		clientv3.OpPut(key, newValue),
-	).Commit()
+	cmps := make([]clientv3.Cmp, len(compare))
+
+	for index, cmp := range compare {
+		cmps[index] = clientv3.Compare(clientv3.Value(cmp.key), "=", cmp.value)
+	}
+
+	ops := make([]clientv3.Op, len(swap))
+	for index, op := range swap {
+		ops[index] = clientv3.OpPut(op.key, op.value)
+	}
+
+	response, err := etcdv3.KV.Txn(ctx).If(cmps...).Then(ops...).Commit()
 
 	if err != nil {
-		log.WithError(err).Error("Unable to compare and swap value by key")
+		keys := []string{}
+		for _, keyValue := range compare {
+			keys = append(keys, keyValue.key)
+		}
+		log = log.WithField("keys", strings.Join(keys, ", "))
+		log.WithError(err).Error("Unable to compare and swap value by keys")
 		return false, err
 	}
 

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -168,6 +168,81 @@ func (suite *EtcdTestSuite) TestEtcdCAS() {
 	assert.Nil(t, err)
 	assert.False(t, ok)
 }
+func (suite *EtcdTestSuite) TestEtcdExtendedCAS() {
+
+	t := suite.T()
+	client := suite.client
+
+	key1 := "key1"
+	expect1 := "expect1"
+
+	key2 := "key2"
+	expect2 := "expect2"
+	update2 := "update2"
+
+	key3 := "key3"
+	update3 := "update3"
+
+	err := client.Put(key1, expect1)
+	assert.Nil(t, err)
+
+	err = client.Put(key2, expect2)
+	assert.Nil(t, err)
+
+	assertGet(suite, key1, expect1)
+	assertGet(suite, key2, expect2)
+
+	ok, err := client.ExtendedCompareAndSwap(
+		[]EtcdKeyValue{
+			EtcdKeyValue{key: key1, value: expect1},
+			EtcdKeyValue{key: key2, value: expect2},
+		},
+		[]EtcdKeyValue{
+			EtcdKeyValue{key: key2, value: update2},
+			EtcdKeyValue{key: key3, value: update3},
+		},
+	)
+	assert.Nil(t, err)
+	assert.True(t, ok)
+
+	assertGet(suite, key1, expect1)
+	assertGet(suite, key2, update2)
+	assertGet(suite, key3, update3)
+
+	ok, err = client.ExtendedCompareAndSwap(
+		[]EtcdKeyValue{
+			EtcdKeyValue{key: key1, value: expect1},
+			EtcdKeyValue{key: key2, value: expect2},
+		},
+		[]EtcdKeyValue{
+			EtcdKeyValue{key: key2, value: update2},
+			EtcdKeyValue{key: key3, value: update3},
+		},
+	)
+	assert.Nil(t, err)
+	assert.False(t, ok)
+
+	assertGet(suite, key1, expect1)
+	assertGet(suite, key2, update2)
+	assertGet(suite, key3, update3)
+
+	ok, err = client.ExtendedCompareAndSwap(
+		[]EtcdKeyValue{
+			EtcdKeyValue{key: key1, value: expect1},
+			EtcdKeyValue{key: key2, value: update2},
+			EtcdKeyValue{key: key3, value: update3},
+		},
+		[]EtcdKeyValue{
+			EtcdKeyValue{key: key2, value: expect2},
+		},
+	)
+	assert.Nil(t, err)
+	assert.True(t, ok)
+
+	assertGet(suite, key1, expect1)
+	assertGet(suite, key2, expect2)
+	assertGet(suite, key3, update3)
+}
 
 func (suite *EtcdTestSuite) TestEtcdNilValue() {
 
@@ -262,6 +337,14 @@ func (suite *EtcdTestSuite) TestEtcdMutex() {
 	assert.True(t, ok)
 	assert.Nil(t, err)
 	assert.Equal(t, res1, res2)
+}
+
+func assertGet(suite *EtcdTestSuite, key string, value string) {
+	t := suite.T()
+	updateResult, ok, err := suite.client.Get(key)
+	assert.Nil(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, value, updateResult)
 }
 
 type keyValue struct {

--- a/etcddb/etcddb_test.go
+++ b/etcddb/etcddb_test.go
@@ -168,7 +168,7 @@ func (suite *EtcdTestSuite) TestEtcdCAS() {
 	assert.Nil(t, err)
 	assert.False(t, ok)
 }
-func (suite *EtcdTestSuite) TestEtcdExtendedCAS() {
+func (suite *EtcdTestSuite) TestEtcdTransaction() {
 
 	t := suite.T()
 	client := suite.client
@@ -192,7 +192,7 @@ func (suite *EtcdTestSuite) TestEtcdExtendedCAS() {
 	assertGet(suite, key1, expect1)
 	assertGet(suite, key2, expect2)
 
-	ok, err := client.ExtendedCompareAndSwap(
+	ok, err := client.Transaction(
 		[]EtcdKeyValue{
 			EtcdKeyValue{key: key1, value: expect1},
 			EtcdKeyValue{key: key2, value: expect2},
@@ -209,7 +209,7 @@ func (suite *EtcdTestSuite) TestEtcdExtendedCAS() {
 	assertGet(suite, key2, update2)
 	assertGet(suite, key3, update3)
 
-	ok, err = client.ExtendedCompareAndSwap(
+	ok, err = client.Transaction(
 		[]EtcdKeyValue{
 			EtcdKeyValue{key: key1, value: expect1},
 			EtcdKeyValue{key: key2, value: expect2},
@@ -226,7 +226,7 @@ func (suite *EtcdTestSuite) TestEtcdExtendedCAS() {
 	assertGet(suite, key2, update2)
 	assertGet(suite, key3, update3)
 
-	ok, err = client.ExtendedCompareAndSwap(
+	ok, err = client.Transaction(
 		[]EtcdKeyValue{
 			EtcdKeyValue{key: key1, value: expect1},
 			EtcdKeyValue{key: key2, value: update2},


### PR DESCRIPTION
The etcd client Transaction method uses an array of key/values to call compare and swap operation.

For example:
```
ok, err := client.Transaction(
		[]EtcdKeyValue{
			EtcdKeyValue{key: key1, value: expect1},
			EtcdKeyValue{key: key2, value: expect2},
		},
		[]EtcdKeyValue{
			EtcdKeyValue{key: key2, value: update2},
			EtcdKeyValue{key: key3, value: update3},
		},
	)

```

Another approach is to use maps as arguments in the Transaction method: https://github.com/stellarspot/snet-daemon/commit/aeeb5519bbf11142be24bada62ce53171cf4731d
```
	expect := map[string]string{
		key1: expect1,
		key2: expect2,
	}
	swap := map[string]string{
		key2: update2,
		key3: update3,
	}

	ok, err := client.Transaction(expect, swap)

```

This does not require additional EtcdKeyValue struct but using maps itself can give additional memory overhead on each Transaction method invocation.