### PR TITLE
Add command to list payments in progress

### DIFF
--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -114,6 +114,24 @@ func (h *lockingPaymentChannelService) StartClaim(key *PaymentChannelKey, update
 	}, nil
 }
 
+func (h *lockingPaymentChannelService) ListClaims() (claims []Claim, err error) {
+	payments, err := h.paymentStorage.GetAll()
+	if err != nil {
+		return
+	}
+
+	claims = make([]Claim, 0, len(payments))
+	for _, payment := range payments {
+		claim := &claimImpl{
+			paymentStorage: h.paymentStorage,
+			payment:        payment,
+		}
+		claims = append(claims, claim)
+	}
+
+	return
+}
+
 func getPaymentFromChannel(channel *PaymentChannelData) *Payment {
 	return &Payment{
 		// TODO: add MpeContractAddress to channel state

--- a/escrow/escrow_test.go
+++ b/escrow/escrow_test.go
@@ -84,6 +84,7 @@ type PaymentChannelServiceSuite struct {
 	mpeContractAddress common.Address
 	memoryStorage      *memoryStorage
 	storage            *PaymentChannelStorage
+	paymentStorage     *PaymentStorage
 
 	service PaymentChannelService
 }
@@ -95,6 +96,7 @@ func (suite *PaymentChannelServiceSuite) SetupSuite() {
 	suite.mpeContractAddress = blockchain.HexToAddress("0xf25186b5081ff5ce73482ad761db0eb0d25abfbf")
 	suite.memoryStorage = NewMemStorage()
 	suite.storage = NewPaymentChannelStorage(suite.memoryStorage)
+	suite.paymentStorage = NewPaymentStorage(suite.memoryStorage)
 
 	err := suite.storage.Put(suite.channelKey(), suite.channel())
 	if err != nil {
@@ -103,7 +105,7 @@ func (suite *PaymentChannelServiceSuite) SetupSuite() {
 
 	suite.service = NewPaymentChannelService(
 		suite.storage,
-		NewPaymentStorage(suite.memoryStorage),
+		suite.paymentStorage,
 		&BlockchainChannelReader{
 			replicaGroupID: func() (*big.Int, error) { return big.NewInt(123), nil },
 			readChannelFromBlockchain: func(channelID *big.Int) (*blockchain.MultiPartyEscrowChannel, bool, error) {
@@ -139,10 +141,10 @@ func (suite *PaymentChannelServiceSuite) mpeChannel() *blockchain.MultiPartyEscr
 
 func (suite *PaymentChannelServiceSuite) payment() *Payment {
 	payment := &Payment{
-		Amount:             big.NewInt(12300),
-		ChannelID:          big.NewInt(42),
-		ChannelNonce:       big.NewInt(3),
-		MpeContractAddress: suite.mpeContractAddress,
+		Amount:       big.NewInt(12300),
+		ChannelID:    big.NewInt(42),
+		ChannelNonce: big.NewInt(3),
+		//MpeContractAddress: suite.mpeContractAddress,
 	}
 	SignTestPayment(payment, suite.senderPrivateKey)
 	return payment
@@ -232,4 +234,17 @@ func (suite *PaymentChannelServiceSuite) TestPaymentSequentialTransaction() {
 	assert.Nil(suite.T(), errD, "Unexpected error: %v", errD)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), suite.channelPlusPayment(paymentB), channel)
+}
+
+func (suite *PaymentChannelServiceSuite) TestStartClaim() {
+	transaction, _ := suite.service.StartPaymentTransaction(suite.payment())
+	transaction.Commit()
+
+	claim, errA := suite.service.StartClaim(suite.channelKey(), IncrementChannelNonce)
+	claims, errB := suite.paymentStorage.GetAll()
+
+	assert.Nil(suite.T(), errA, "Unexpected error: %v", errA)
+	assert.Nil(suite.T(), errB, "Unexpected error: %v", errB)
+	assert.Equal(suite.T(), suite.payment(), claim.Payment())
+	assert.Equal(suite.T(), []*Payment{suite.payment()}, claims)
 }

--- a/escrow/memory_storage.go
+++ b/escrow/memory_storage.go
@@ -11,7 +11,7 @@ type memoryStorage struct {
 }
 
 // NewMemStorage returns new in-memory atomic storage implementation
-func NewMemStorage() (storage AtomicStorage) {
+func NewMemStorage() (storage *memoryStorage) {
 	return &memoryStorage{
 		data:  make(map[string]string),
 		mutex: &sync.RWMutex{},
@@ -95,6 +95,15 @@ func (storage *memoryStorage) Delete(key string) (err error) {
 	defer storage.mutex.Unlock()
 
 	delete(storage.data, key)
+
+	return
+}
+
+func (storage *memoryStorage) Clear() (err error) {
+	storage.mutex.Lock()
+	defer storage.mutex.Unlock()
+
+	storage.data = make(map[string]string)
 
 	return
 }

--- a/escrow/payment_channel_api.go
+++ b/escrow/payment_channel_api.go
@@ -109,6 +109,8 @@ type PaymentChannelService interface {
 	// StartClaim gets channel from storage, applies update on it and adds
 	// payment for claiming into the storage.
 	StartClaim(key *PaymentChannelKey, update ChannelUpdate) (claim Claim, err error)
+	// ListClaims returns list of payment claims in progress
+	ListClaims() (claim []Claim, err error)
 
 	// StartPaymentTransaction validates payment and starts payment transaction
 	StartPaymentTransaction(payment *Payment) (transaction PaymentTransaction, err error)

--- a/escrow/payment_channel_api.go
+++ b/escrow/payment_channel_api.go
@@ -29,6 +29,10 @@ func (p *Payment) String() string {
 		blockchain.AddressToHex(&p.MpeContractAddress), p.ChannelID, p.ChannelNonce, p.Amount, blockchain.BytesToBase64(p.Signature))
 }
 
+func (p *Payment) ID() string {
+	return fmt.Sprintf("%v/%v", p.ChannelID, p.ChannelNonce)
+}
+
 // PaymentChannelKey specifies the channel in MultiPartyEscrow contract. It
 // consists of two parts: channel id and channel nonce. Channel nonce is
 // incremented each time when amount of tokens in channel descreases. Nonce

--- a/escrow/payment_channel_storage_test.go
+++ b/escrow/payment_channel_storage_test.go
@@ -27,6 +27,7 @@ type PaymentChannelStorageSuite struct {
 
 	senderAddress    common.Address
 	recipientAddress common.Address
+	memoryStorage    *memoryStorage
 
 	storage *PaymentChannelStorage
 }
@@ -34,8 +35,13 @@ type PaymentChannelStorageSuite struct {
 func (suite *PaymentChannelStorageSuite) SetupSuite() {
 	suite.senderAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.recipientAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
+	suite.memoryStorage = NewMemStorage()
 
-	suite.storage = NewPaymentChannelStorage(NewMemStorage())
+	suite.storage = NewPaymentChannelStorage(suite.memoryStorage)
+}
+
+func (suite *PaymentChannelStorageSuite) SetupTest() {
+	suite.memoryStorage.Clear()
 }
 
 func TestPaymentChannelStorageSuite(t *testing.T) {

--- a/escrow/payment_storage.go
+++ b/escrow/payment_storage.go
@@ -1,7 +1,6 @@
 package escrow
 
 import (
-	"fmt"
 	"reflect"
 )
 
@@ -38,13 +37,9 @@ func (storage *PaymentStorage) GetAll() (states []*Payment, err error) {
 }
 
 func (storage *PaymentStorage) Put(payment *Payment) (err error) {
-	return storage.delegate.Put(paymentKey(payment), payment)
+	return storage.delegate.Put(payment.ID(), payment)
 }
 
 func (storage *PaymentStorage) Delete(payment *Payment) (err error) {
-	return storage.delegate.Delete(paymentKey(payment))
-}
-
-func paymentKey(payment *Payment) string {
-	return fmt.Sprintf("%v/%v", payment.ChannelID, payment.ChannelNonce)
+	return storage.delegate.Delete(payment.ID())
 }

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -88,6 +88,7 @@ func init() {
 	RootCmd.AddCommand(ListCmd)
 
 	ListCmd.AddCommand(ListChannelsCmd)
+	ListCmd.AddCommand(ListClaimsCmd)
 
 	ClaimCmd.Flags().StringVar(&claimChannelId, ClaimChannelIdFlag, "", "id of the payment channel to claim money")
 	ClaimCmd.MarkFlagRequired(ClaimChannelIdFlag)

--- a/snetd/cmd/flags.go
+++ b/snetd/cmd/flags.go
@@ -50,6 +50,7 @@ var ListCmd = &cobra.Command{
 
 const (
 	ClaimChannelIdFlag = "channel-id"
+	ClaimPaymentIdFlag = "payment-id"
 	ClaimSendBackFlag  = "send-back"
 	ClaimTimeoutFlag   = "timeout"
 )
@@ -74,6 +75,7 @@ var (
 	pollSleep          = ServeCmd.PersistentFlags().String("poll-sleep", "5s", "blockchain poll sleep time")
 
 	claimChannelId string
+	claimPaymentId string
 	claimSendBack  bool
 	claimTimeout   string
 )
@@ -90,8 +92,8 @@ func init() {
 	ListCmd.AddCommand(ListChannelsCmd)
 	ListCmd.AddCommand(ListClaimsCmd)
 
-	ClaimCmd.Flags().StringVar(&claimChannelId, ClaimChannelIdFlag, "", "id of the payment channel to claim money")
-	ClaimCmd.MarkFlagRequired(ClaimChannelIdFlag)
+	ClaimCmd.Flags().StringVar(&claimChannelId, ClaimChannelIdFlag, "", "id of the payment channel to claim money, see \"list channels\"")
+	ClaimCmd.Flags().StringVar(&claimPaymentId, ClaimPaymentIdFlag, "", "id of the payment to claim money, see \"list payments\"")
 	ClaimCmd.Flags().BoolVar(&claimSendBack, ClaimSendBackFlag, false, "send the rest of the channel value back to channel sender")
 	ClaimCmd.Flags().StringVar(&claimTimeout, ClaimTimeoutFlag, "5s", "timeout for blockchain transaction")
 

--- a/snetd/cmd/list_channels.go
+++ b/snetd/cmd/list_channels.go
@@ -40,7 +40,7 @@ func (command *listChannelsCommand) Run() (err error) {
 	}
 
 	for _, channel := range channels {
-		fmt.Println(channel.String())
+		fmt.Printf("%v: %v\n", channel.ChannelID, channel)
 	}
 
 	return nil

--- a/snetd/cmd/list_claims.go
+++ b/snetd/cmd/list_claims.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/singnet/snet-daemon/escrow"
+)
+
+// ListClaimsCmd shows list of channels from shared storage
+var ListClaimsCmd = &cobra.Command{
+	Use:   "claims",
+	Short: "List payments which are not written to blockchain yet",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RunAndCleanup(cmd, args, newListClaimsCommand)
+	},
+}
+
+type listClaimsCommand struct {
+	channelService escrow.PaymentChannelService
+}
+
+func newListClaimsCommand(cmd *cobra.Command, args []string, components *Components) (command Command, err error) {
+	command = &listClaimsCommand{
+		channelService: components.PaymentChannelService(),
+	}
+
+	return
+}
+
+func (command *listClaimsCommand) Run() (err error) {
+	claims, err := command.channelService.ListClaims()
+	if err != nil {
+		return
+	}
+
+	if len(claims) == 0 {
+		fmt.Println("no claims in shared storage")
+	}
+
+	for _, claim := range claims {
+		fmt.Println(claim.Payment().String())
+	}
+
+	return nil
+}

--- a/snetd/cmd/list_claims.go
+++ b/snetd/cmd/list_claims.go
@@ -40,7 +40,8 @@ func (command *listClaimsCommand) Run() (err error) {
 	}
 
 	for _, claim := range claims {
-		fmt.Println(claim.Payment().String())
+		payment := claim.Payment()
+		fmt.Printf("%v: %v\n", payment.ID(), payment)
 	}
 
 	return nil


### PR DESCRIPTION
Work for issue https://github.com/singnet/snet-daemon/issues/108:
- new command ```snetd list claims``` is added to list payments which were started but not written to the blockchain yet
- new flag ```--payment-id``` is added to ```snetd claim``` command for writing started payment to the blockchain