### PR TITLE
Unlock payment channel during payment transaction rollback.

### DIFF
--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -230,5 +230,11 @@ func (payment *paymentTransaction) Commit() error {
 }
 
 func (payment *paymentTransaction) Rollback() error {
+	defer func(payment *paymentTransaction) {
+		err := payment.lock.Unlock()
+		if err != nil {
+			log.WithError(err).WithField("payment", payment).Error("Channel cannot be unlocked because of error. All other transactions on this channel will be blocked until unlock. Please unlock channel manually.")
+		}
+	}(payment)
 	return nil
 }


### PR DESCRIPTION
Fix issue that payment channel is locked when service returns error.