### PR TITLE
Remove private key validation for daemon

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -140,3 +140,7 @@ func (processor *Processor) CurrentBlock() (currentBlock *big.Int, err error) {
 
 	return
 }
+
+func (processor *Processor) HasIdentity() bool {
+	return processor.address != ""
+}

--- a/config/config.go
+++ b/config/config.go
@@ -143,12 +143,6 @@ func Validate() error {
 		return fmt.Errorf("unrecognized DAEMON_TYPE '%+v'", dType)
 	}
 
-	if vip.GetBool(BlockchainEnabledKey) {
-		if vip.GetString(PrivateKeyKey) == "" && vip.GetString(HdwalletMnemonicKey) == "" {
-			return errors.New("either PRIVATE_KEY or HDWALLET_MNEMONIC are required")
-		}
-	}
-
 	certPath, keyPath := vip.GetString(SSLCertPathKey), vip.GetString(SSLKeyPathKey)
 	if (certPath != "" && keyPath == "") || (certPath == "" && keyPath != "") {
 		return errors.New("SSL requires both key and certificate when enabled")

--- a/snetd/cmd/claim.go
+++ b/snetd/cmd/claim.go
@@ -74,6 +74,9 @@ func (command *claimCommand) Run() (err error) {
 	if !command.blockchain.Enabled() {
 		return fmt.Errorf("blockchain should be enabled to claim money from channel")
 	}
+	if !command.blockchain.HasIdentity() {
+		return fmt.Errorf("Either private key or HD wallet should be specified in order to claim funds")
+	}
 	if command.channelId == nil && command.paymentId == "" {
 		return fmt.Errorf("either --channel-id or --payment-id flag should be set")
 	}


### PR DESCRIPTION
As private key is needed for ```snetd claim``` command only it should not be validated during starting of the daemon. ```snetd claim``` checks that blockchain component has configured identity instead.