### PR TITLE
#Issue 158 

### DIFF
--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -88,9 +88,9 @@ func newDaemon(components *Components) (daemon, error) {
 	d.components = components
 
 	var err error
-	port, portErr := deriveDaemonPort(config.GetString(config.DaemonEndPoint))
+	port, err := deriveDaemonPort(config.GetString(config.DaemonEndPoint))
 
-	if portErr != nil {
+	if err != nil {
 		return d, errors.Wrap(err, "error determining port")
 	}
 
@@ -126,6 +126,11 @@ func deriveDaemonPort(daemonEndpoint string) (string, error) {
 	port := "8080"
 	var err error = nil
 
+	//There is a separate issue raised on standardizing the daemon end point format, #153, Daemon end point can also
+	//be entered in the format localhost:8080 or 127.1.0.0:8080 ( as this is allowed while defining the service metadata )
+	//For now strip http: or https: from the daemonEndPoint
+	daemonEndpoint = strings.Replace(daemonEndpoint, "https://", "", -1)
+	daemonEndpoint = strings.Replace(daemonEndpoint, "http://", "", -1)
 	splitString := strings.Split(daemonEndpoint, ":")
 	length := len(splitString)
 	if length == 2 {

--- a/snetd/cmd/serve_test.go
+++ b/snetd/cmd/serve_test.go
@@ -11,12 +11,20 @@ func TestDeriveDaemonPort(t *testing.T) {
 	assert.Equal(t, "8111", port1)
 
 	port1, err = deriveDaemonPort("http://127.0.0.1:8111")
-	assert.Equal(t, "daemon end point should have a single ':' ,the daemon End point http://127.0.0.1:8111", err.Error())
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "8111", port1)
+
+	port1, err = deriveDaemonPort("https://127.0.0.1:8111")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "8111", port1)
 
 	port1, err = deriveDaemonPort("abcdefjl:wewee")
 	assert.Equal(t, "port number <wewee> is not valid ,the daemon End point  abcdefjl:wewee", err.Error())
 
 	port1, err = deriveDaemonPort("localhost:80:500")
+	assert.Equal(t, "daemon end point should have a single ':' ,the daemon End point localhost:80:500", err.Error())
+
+	port1, err = deriveDaemonPort("http://localhost:80:500")
 	assert.Equal(t, "daemon end point should have a single ':' ,the daemon End point localhost:80:500", err.Error())
 
 	port1, err = deriveDaemonPort("")


### PR DESCRIPTION
1) Correct the typo on the variable used to check error
2) Deriving the port number when the daemon end point is of any format below
    http://localhost:8080
    https://localhost:8080
    localhost:8080
    127.0.0.1:8080
https://github.com/singnet/snet-daemon/issues/158