### PR TITLE
Return incorrect nonce error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ blockchain/registry.go
 blockchain/multi_party_escrow.go
 blockchain/singularity_net_token.go
 escrow/state_service.pb.go
+handler/grpc_test.pb.go
 
 # Binaries for programs and plugins
 *.exe

--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -163,7 +163,7 @@ func (h *lockingPaymentChannelService) StartPaymentTransaction(payment *Payment)
 
 	lock, ok, err := h.locker.Lock(channelKey.String())
 	if err != nil {
-		return nil, NewPaymentError(FailedPrecondition, "cannot get mutex for channel: %v", channelKey)
+		return nil, NewPaymentError(Internal, "cannot get mutex for channel: %v", channelKey)
 	}
 	if !ok {
 		return nil, NewPaymentError(FailedPrecondition, "another transaction on channel: %v is in progress", channelKey)

--- a/escrow/income.go
+++ b/escrow/income.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/singnet/snet-daemon/handler"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // IncomeData is used to pass information to the pricing validation system.
@@ -29,7 +28,7 @@ type IncomeData struct {
 type IncomeValidator interface {
 	// Validate returns nil if validation is successful or correct gRPC status
 	// to be sent to client in case of validation error.
-	Validate(*IncomeData) (err *status.Status)
+	Validate(*IncomeData) (err *handler.GrpcError)
 }
 
 type incomeValidator struct {
@@ -41,12 +40,12 @@ func NewIncomeValidator(priceInCogs *big.Int) (validator IncomeValidator) {
 	return &incomeValidator{priceInCogs: priceInCogs}
 }
 
-func (validator *incomeValidator) Validate(data *IncomeData) (err *status.Status) {
+func (validator *incomeValidator) Validate(data *IncomeData) (err *handler.GrpcError) {
 
 	price := validator.priceInCogs
 
 	if data.Income.Cmp(price) != 0 {
-		err = status.Newf(codes.Unauthenticated, "income %d does not equal to price %d", data.Income, price)
+		err = handler.NewGrpcErrorf(codes.Unauthenticated, "income %d does not equal to price %d", data.Income, price)
 		return
 	}
 

--- a/escrow/income_test.go
+++ b/escrow/income_test.go
@@ -6,16 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/codes"
-
-	"github.com/singnet/snet-daemon/handler"
 )
 
 type incomeValidatorMockType struct {
-	err *handler.GrpcError
+	err error
 }
 
-func (incomeValidator *incomeValidatorMockType) Validate(income *IncomeData) (err *handler.GrpcError) {
+func (incomeValidator *incomeValidatorMockType) Validate(income *IncomeData) (err error) {
 	return incomeValidator.err
 }
 
@@ -28,7 +25,7 @@ func TestIncomeValidate(t *testing.T) {
 	income.Sub(price, one)
 	err := incomeValidator.Validate(&IncomeData{Income: income})
 	msg := fmt.Sprintf("income %s does not equal to price %s", income, price)
-	assert.Equal(t, handler.NewGrpcError(codes.Unauthenticated, msg), err)
+	assert.Equal(t, NewPaymentError(Unauthenticated, msg), err)
 
 	income.Set(price)
 	err = incomeValidator.Validate(&IncomeData{Income: income})
@@ -37,5 +34,5 @@ func TestIncomeValidate(t *testing.T) {
 	income.Add(price, one)
 	err = incomeValidator.Validate(&IncomeData{Income: income})
 	msg = fmt.Sprintf("income %s does not equal to price %s", income, price)
-	assert.Equal(t, handler.NewGrpcError(codes.Unauthenticated, msg), err)
+	assert.Equal(t, NewPaymentError(Unauthenticated, msg), err)
 }

--- a/escrow/income_test.go
+++ b/escrow/income_test.go
@@ -2,18 +2,20 @@ package escrow
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+
+	"github.com/singnet/snet-daemon/handler"
 )
 
 type incomeValidatorMockType struct {
-	err *status.Status
+	err *handler.GrpcError
 }
 
-func (incomeValidator *incomeValidatorMockType) Validate(income *IncomeData) (err *status.Status) {
+func (incomeValidator *incomeValidatorMockType) Validate(income *IncomeData) (err *handler.GrpcError) {
 	return incomeValidator.err
 }
 
@@ -26,7 +28,7 @@ func TestIncomeValidate(t *testing.T) {
 	income.Sub(price, one)
 	err := incomeValidator.Validate(&IncomeData{Income: income})
 	msg := fmt.Sprintf("income %s does not equal to price %s", income, price)
-	assert.Equal(t, status.New(codes.Unauthenticated, msg), err)
+	assert.Equal(t, handler.NewGrpcError(codes.Unauthenticated, msg), err)
 
 	income.Set(price)
 	err = incomeValidator.Validate(&IncomeData{Income: income})
@@ -35,5 +37,5 @@ func TestIncomeValidate(t *testing.T) {
 	income.Add(price, one)
 	err = incomeValidator.Validate(&IncomeData{Income: income})
 	msg = fmt.Sprintf("income %s does not equal to price %s", income, price)
-	assert.Equal(t, status.New(codes.Unauthenticated, msg), err)
+	assert.Equal(t, handler.NewGrpcError(codes.Unauthenticated, msg), err)
 }

--- a/escrow/payment_channel_api.go
+++ b/escrow/payment_channel_api.go
@@ -134,6 +134,8 @@ const (
 	// FailedPrecondition means that request cannot be handled because system
 	// is not in appropriate state.
 	FailedPrecondition PaymentErrorCode = 3
+	// IncorrectNonce is returned when nonce value sent by client is incorrect.
+	IncorrectNonce PaymentErrorCode = 4
 )
 
 // PaymentError contains error code and message and implements Error interface.

--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -128,6 +128,8 @@ func paymentErrorToGrpcError(err error) *handler.GrpcError {
 		grpcCode = codes.Unauthenticated
 	case FailedPrecondition:
 		grpcCode = codes.FailedPrecondition
+	case IncorrectNonce:
+		grpcCode = handler.IncorrectNonce
 	default:
 		grpcCode = codes.Internal
 	}

--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -104,10 +104,6 @@ func (h *paymentChannelPaymentHandler) getPaymentFromContext(context *handler.Gr
 	}, nil
 }
 
-func (h *paymentChannelPaymentHandler) Validate(_payment handler.Payment) (err *status.Status) {
-	return nil
-}
-
 func (h *paymentChannelPaymentHandler) Complete(payment handler.Payment) (err *status.Status) {
 	return paymentErrorToGrpcStatus(payment.(*paymentTransaction).Commit())
 }

--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -65,9 +65,9 @@ func (h *paymentChannelPaymentHandler) Payment(context *handler.GrpcStreamContex
 
 	income := big.NewInt(0)
 	income.Sub(internalPayment.Amount, transaction.Channel().AuthorizedAmount)
-	err = h.incomeValidator.Validate(&IncomeData{Income: income, GrpcContext: context})
-	if err != nil {
-		return
+	e = h.incomeValidator.Validate(&IncomeData{Income: income, GrpcContext: context})
+	if e != nil {
+		return nil, paymentErrorToGrpcError(e)
 	}
 
 	return transaction, nil

--- a/escrow/payment_handler_test.go
+++ b/escrow/payment_handler_test.go
@@ -134,12 +134,12 @@ func (suite *PaymentHandlerTestSuite) TestStartTransactionError() {
 
 func (suite *PaymentHandlerTestSuite) TestValidatePaymentIncorrectIncome() {
 	context := suite.grpcContext(func(md *metadata.MD) {})
-	incomeErr := handler.NewGrpcError(codes.Unauthenticated, "incorrect payment income: \"45\", expected \"46\"")
+	incomeErr := NewPaymentError(Unauthenticated, "incorrect payment income: \"45\", expected \"46\"")
 	paymentHandler := suite.paymentHandler
 	paymentHandler.incomeValidator = &incomeValidatorMockType{err: incomeErr}
 
 	payment, err := paymentHandler.Payment(context)
 
-	assert.Equal(suite.T(), incomeErr, err)
+	assert.Equal(suite.T(), handler.NewGrpcError(codes.Unauthenticated, "incorrect payment income: \"45\", expected \"46\""), err)
 	assert.Nil(suite.T(), payment)
 }

--- a/escrow/payment_handler_test.go
+++ b/escrow/payment_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 
 	"github.com/singnet/snet-daemon/blockchain"
 	"github.com/singnet/snet-daemon/handler"
@@ -73,7 +72,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPayment() {
 
 	_, err := suite.paymentHandler.Payment(context)
 
-	assert.Nil(suite.T(), err, "Unexpected error: %v", err.Message())
+	assert.Nil(suite.T(), err, "Unexpected error: %v", err)
 }
 
 func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelId() {
@@ -83,7 +82,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelId() {
 
 	payment, err := suite.paymentHandler.Payment(context)
 
-	assert.Equal(suite.T(), status.New(codes.InvalidArgument, "missing \"snet-payment-channel-id\""), err)
+	assert.Equal(suite.T(), handler.NewGrpcError(codes.InvalidArgument, "missing \"snet-payment-channel-id\""), err)
 	assert.Nil(suite.T(), payment)
 }
 
@@ -94,7 +93,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelNonce() {
 
 	payment, err := suite.paymentHandler.Payment(context)
 
-	assert.Equal(suite.T(), status.New(codes.InvalidArgument, "missing \"snet-payment-channel-nonce\""), err)
+	assert.Equal(suite.T(), handler.NewGrpcError(codes.InvalidArgument, "missing \"snet-payment-channel-nonce\""), err)
 	assert.Nil(suite.T(), payment)
 }
 
@@ -105,7 +104,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelAmount() {
 
 	payment, err := suite.paymentHandler.Payment(context)
 
-	assert.Equal(suite.T(), status.New(codes.InvalidArgument, "missing \"snet-payment-channel-amount\""), err)
+	assert.Equal(suite.T(), handler.NewGrpcError(codes.InvalidArgument, "missing \"snet-payment-channel-amount\""), err)
 	assert.Nil(suite.T(), payment)
 }
 
@@ -116,7 +115,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoSignature() {
 
 	payment, err := suite.paymentHandler.Payment(context)
 
-	assert.Equal(suite.T(), status.New(codes.InvalidArgument, "missing \"snet-payment-channel-signature-bin\""), err)
+	assert.Equal(suite.T(), handler.NewGrpcError(codes.InvalidArgument, "missing \"snet-payment-channel-signature-bin\""), err)
 	assert.Nil(suite.T(), payment)
 }
 
@@ -129,13 +128,13 @@ func (suite *PaymentHandlerTestSuite) TestStartTransactionError() {
 
 	payment, err := paymentHandler.Payment(context)
 
-	assert.Equal(suite.T(), status.New(codes.FailedPrecondition, "another transaction in progress"), err)
+	assert.Equal(suite.T(), handler.NewGrpcError(codes.FailedPrecondition, "another transaction in progress"), err)
 	assert.Nil(suite.T(), payment)
 }
 
 func (suite *PaymentHandlerTestSuite) TestValidatePaymentIncorrectIncome() {
 	context := suite.grpcContext(func(md *metadata.MD) {})
-	incomeErr := status.New(codes.Unauthenticated, "incorrect payment income: \"45\", expected \"46\"")
+	incomeErr := handler.NewGrpcError(codes.Unauthenticated, "incorrect payment income: \"45\", expected \"46\"")
 	paymentHandler := suite.paymentHandler
 	paymentHandler.incomeValidator = &incomeValidatorMockType{err: incomeErr}
 

--- a/escrow/validation.go
+++ b/escrow/validation.go
@@ -36,7 +36,7 @@ func (validator *ChannelPaymentValidator) Validate(payment *Payment, channel *Pa
 
 	if payment.ChannelNonce.Cmp(channel.Nonce) != 0 {
 		log.Warn("Incorrect nonce is sent by client")
-		return NewPaymentError(Unauthenticated, "incorrect payment channel nonce, latest: %v, sent: %v", channel.Nonce, payment.ChannelNonce)
+		return NewPaymentError(IncorrectNonce, "incorrect payment channel nonce, latest: %v, sent: %v", channel.Nonce, payment.ChannelNonce)
 	}
 
 	signerAddress, err := getSignerAddressFromPayment(payment)

--- a/escrow/validation_test.go
+++ b/escrow/validation_test.go
@@ -126,7 +126,7 @@ func (suite *ValidationTestSuite) TestValidatePaymentChannelNonce() {
 
 	err := suite.validator.Validate(payment, channel)
 
-	assert.Equal(suite.T(), NewPaymentError(Unauthenticated, "incorrect payment channel nonce, latest: 3, sent: 2"), err)
+	assert.Equal(suite.T(), NewPaymentError(IncorrectNonce, "incorrect payment channel nonce, latest: 3, sent: 2"), err)
 }
 
 func (suite *ValidationTestSuite) TestValidatePaymentIncorrectSignatureLength() {

--- a/handler/grpc_test.go
+++ b/handler/grpc_test.go
@@ -1,0 +1,75 @@
+//go:generate protoc grpc_test.proto --go_out=plugins=grpc:.
+
+package handler
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+type GrpcTestSuite struct {
+	suite.Suite
+}
+
+func (suite *GrpcTestSuite) SetupSuite() {
+}
+
+func (suite *GrpcTestSuite) TearDownSuite() {
+}
+
+func TestGrpcTestSuite(t *testing.T) {
+	suite.Run(t, new(GrpcTestSuite))
+}
+
+type exampleServiceMock struct {
+	output *Output
+	err    error
+}
+
+func (service *exampleServiceMock) Ping(context context.Context, input *Input) (output *Output, err error) {
+	return service.output, service.err
+}
+
+func startServiceAndClient(service ExampleServiceServer) (ExampleServiceClient, *grpc.ClientConn) {
+	ch := make(chan int)
+	go func() {
+		listener, err := net.Listen("tcp", ":12345")
+		if err != nil {
+			panic(err)
+		}
+
+		server := grpc.NewServer()
+		RegisterExampleServiceServer(server, service)
+
+		ch <- 0
+
+		server.Serve(listener)
+	}()
+
+	_ = <-ch
+
+	connection, err := grpc.Dial("localhost:12345", grpc.WithInsecure())
+	if err != nil {
+		panic(err)
+	}
+
+	client := NewExampleServiceClient(connection)
+
+	return client, connection
+}
+
+func (suite *GrpcTestSuite) TestReturnCustomErrorCodeViaGrpc() {
+	expectedErr := status.Newf(1000, "error message").Err()
+	client, connection := startServiceAndClient(&exampleServiceMock{err: expectedErr})
+	defer connection.Close()
+
+	_, err := client.Ping(context.Background(), &Input{Message: "ping"})
+
+	assert.Equal(suite.T(), err, expectedErr)
+}

--- a/handler/grpc_test.proto
+++ b/handler/grpc_test.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package handler;
+
+service ExampleService {
+    rpc Ping(Input) returns (Output) {}
+}
+
+message Input {
+    string message = 1;
+}
+
+message Output {
+    string message = 1;
+}

--- a/handler/interceptors.go
+++ b/handler/interceptors.go
@@ -34,6 +34,14 @@ func (context *GrpcStreamContext) String() string {
 // and used to complete payment.
 type Payment interface{}
 
+// Custom gRPC codes to return to the client
+const (
+	// IncorrectNonce is returned to client when payment recieved contains
+	// incorrect nonce value. Client may use PaymentChannelStateService to get
+	// latest channel state and correct nonce value.
+	IncorrectNonce codes.Code = 1000
+)
+
 // GrpcError is an error which will be returned by interceptor via gRPC
 // protocol. Part of information will be returned as header metadata.
 type GrpcError struct {

--- a/handler/interceptors.go
+++ b/handler/interceptors.go
@@ -47,8 +47,6 @@ const (
 type GrpcError struct {
 	// Status is a gRPC call status
 	Status *status.Status
-	// MD is an metadata to be returned back
-	MD metadata.MD
 }
 
 // Err returns error to return correct gRPC error to the caller
@@ -61,7 +59,7 @@ func (err *GrpcError) Err() error {
 
 // String converts GrpcError to string
 func (err *GrpcError) String() string {
-	return fmt.Sprintf("{Status: %v, MD: %v}", err.Status, err.MD)
+	return fmt.Sprintf("{Status: %v}", err.Status)
 }
 
 // NewGrpcError returns new error which contains gRPC status with provided code

--- a/handler/interceptors.go
+++ b/handler/interceptors.go
@@ -34,6 +34,44 @@ func (context *GrpcStreamContext) String() string {
 // and used to complete payment.
 type Payment interface{}
 
+// GrpcError is an error which will be returned by interceptor via gRPC
+// protocol. Part of information will be returned as header metadata.
+type GrpcError struct {
+	// Status is a gRPC call status
+	Status *status.Status
+	// MD is an metadata to be returned back
+	MD metadata.MD
+}
+
+// Err returns error to return correct gRPC error to the caller
+func (err *GrpcError) Err() error {
+	if err.Status == nil {
+		return nil
+	}
+	return err.Status.Err()
+}
+
+// String converts GrpcError to string
+func (err *GrpcError) String() string {
+	return fmt.Sprintf("{Status: %v, MD: %v}", err.Status, err.MD)
+}
+
+// NewGrpcError returns new error which contains gRPC status with provided code
+// and message
+func NewGrpcError(code codes.Code, message string) *GrpcError {
+	return &GrpcError{
+		Status: status.Newf(code, message),
+	}
+}
+
+// NewGrpcErrorf returns new error which contains gRPC status with provided
+// code and message formed from format string and args.
+func NewGrpcErrorf(code codes.Code, format string, args ...interface{}) *GrpcError {
+	return &GrpcError{
+		Status: status.Newf(code, format, args...),
+	}
+}
+
 // PaymentHandler interface which is used by gRPC interceptor to get, validate
 // and complete payment. There are two payment handler implementations so far:
 // jobPaymentHandler and escrowPaymentHandler. jobPaymentHandler is depreactted.
@@ -44,12 +82,12 @@ type PaymentHandler interface {
 	// Payment extracts payment data from gRPC request context and checks
 	// validity of payment data. It returns nil if data is valid or
 	// appropriate gRPC status otherwise.
-	Payment(context *GrpcStreamContext) (payment Payment, err *status.Status)
+	Payment(context *GrpcStreamContext) (payment Payment, err *GrpcError)
 	// Complete completes payment if gRPC call was successfully proceeded by
 	// service.
-	Complete(payment Payment) (err *status.Status)
+	Complete(payment Payment) (err *GrpcError)
 	// CompleteAfterError completes payment if service returns error.
-	CompleteAfterError(payment Payment, result error) (err *status.Status)
+	CompleteAfterError(payment Payment, result error) (err *GrpcError)
 }
 
 // GrpcStreamInterceptor returns gRPC interceptor to validate payment. If
@@ -77,7 +115,7 @@ type paymentValidationInterceptor struct {
 }
 
 func (interceptor *paymentValidationInterceptor) intercept(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (e error) {
-	var err *status.Status
+	var err *GrpcError
 
 	context, err := getGrpcContext(ss, info)
 	if err != nil {
@@ -132,11 +170,11 @@ func (interceptor *paymentValidationInterceptor) intercept(srv interface{}, ss g
 	return nil
 }
 
-func getGrpcContext(serverStream grpc.ServerStream, info *grpc.StreamServerInfo) (context *GrpcStreamContext, err *status.Status) {
+func getGrpcContext(serverStream grpc.ServerStream, info *grpc.StreamServerInfo) (context *GrpcStreamContext, err *GrpcError) {
 	md, ok := metadata.FromIncomingContext(serverStream.Context())
 	if !ok {
 		log.WithField("info", info).Error("Invalid metadata")
-		return nil, status.New(codes.InvalidArgument, "missing metadata")
+		return nil, NewGrpcError(codes.InvalidArgument, "missing metadata")
 	}
 
 	return &GrpcStreamContext{
@@ -145,7 +183,7 @@ func getGrpcContext(serverStream grpc.ServerStream, info *grpc.StreamServerInfo)
 	}, nil
 }
 
-func (interceptor *paymentValidationInterceptor) getPaymentHandler(context *GrpcStreamContext) (handler PaymentHandler, err *status.Status) {
+func (interceptor *paymentValidationInterceptor) getPaymentHandler(context *GrpcStreamContext) (handler PaymentHandler, err *GrpcError) {
 	paymentTypeMd, ok := context.MD[PaymentTypeHeader]
 	if !ok || len(paymentTypeMd) == 0 {
 		log.WithField("defaultPaymentHandlerType", interceptor.defaultPaymentHandler.Type()).Debug("Payment type was not set by caller, return default payment handler")
@@ -156,7 +194,7 @@ func (interceptor *paymentValidationInterceptor) getPaymentHandler(context *Grpc
 	paymentHandler, ok := interceptor.paymentHandlers[paymentType]
 	if !ok {
 		log.WithField("paymentType", paymentType).Error("Unexpected payment type")
-		return nil, status.Newf(codes.InvalidArgument, "unexpected \"%v\", value: \"%v\"", PaymentTypeHeader, paymentType)
+		return nil, NewGrpcErrorf(codes.InvalidArgument, "unexpected \"%v\", value: \"%v\"", PaymentTypeHeader, paymentType)
 	}
 
 	log.WithField("paymentType", paymentType).Debug("Return payment handler by type")
@@ -164,7 +202,7 @@ func (interceptor *paymentValidationInterceptor) getPaymentHandler(context *Grpc
 }
 
 // GetBigInt gets big.Int value from gRPC metadata
-func GetBigInt(md metadata.MD, key string) (value *big.Int, err *status.Status) {
+func GetBigInt(md metadata.MD, key string) (value *big.Int, err *GrpcError) {
 	str, err := GetSingleValue(md, key)
 	if err != nil {
 		return
@@ -173,7 +211,7 @@ func GetBigInt(md metadata.MD, key string) (value *big.Int, err *status.Status) 
 	value = big.NewInt(0)
 	e := value.UnmarshalText([]byte(str))
 	if e != nil {
-		return nil, status.Newf(codes.InvalidArgument, "incorrect format \"%v\": \"%v\"", key, str)
+		return nil, NewGrpcErrorf(codes.InvalidArgument, "incorrect format \"%v\": \"%v\"", key, str)
 	}
 
 	return
@@ -181,9 +219,9 @@ func GetBigInt(md metadata.MD, key string) (value *big.Int, err *status.Status) 
 
 // GetBytes gets bytes array value from gRPC metadata for key with '-bin'
 // suffix, internally this data is encoded as base64
-func GetBytes(md metadata.MD, key string) (result []byte, err *status.Status) {
+func GetBytes(md metadata.MD, key string) (result []byte, err *GrpcError) {
 	if !strings.HasSuffix(key, "-bin") {
-		return nil, status.Newf(codes.InvalidArgument, "incorrect binary key name \"%v\"", key)
+		return nil, NewGrpcErrorf(codes.InvalidArgument, "incorrect binary key name \"%v\"", key)
 	}
 
 	str, err := GetSingleValue(md, key)
@@ -196,7 +234,7 @@ func GetBytes(md metadata.MD, key string) (result []byte, err *status.Status) {
 
 // GetBytesFromHex gets bytes array value from gRPC metadata, bytes array is
 // encoded as hex string
-func GetBytesFromHex(md metadata.MD, key string) (value []byte, err *status.Status) {
+func GetBytesFromHex(md metadata.MD, key string) (value []byte, err *GrpcError) {
 	str, err := GetSingleValue(md, key)
 	if err != nil {
 		return
@@ -205,15 +243,15 @@ func GetBytesFromHex(md metadata.MD, key string) (value []byte, err *status.Stat
 }
 
 // GetSingleValue gets string value from gRPC metadata
-func GetSingleValue(md metadata.MD, key string) (value string, err *status.Status) {
+func GetSingleValue(md metadata.MD, key string) (value string, err *GrpcError) {
 	array := md.Get(key)
 
 	if len(array) == 0 {
-		return "", status.Newf(codes.InvalidArgument, "missing \"%v\"", key)
+		return "", NewGrpcErrorf(codes.InvalidArgument, "missing \"%v\"", key)
 	}
 
 	if len(array) > 1 {
-		return "", status.Newf(codes.InvalidArgument, "too many values for key \"%v\": %v", key, array)
+		return "", NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"%v\": %v", key, array)
 	}
 
 	return array[0], nil

--- a/handler/interceptors_test.go
+++ b/handler/interceptors_test.go
@@ -1,12 +1,12 @@
 package handler
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
-	"math/big"
-	"testing"
 )
 
 func TestGetBytesFromHexString(t *testing.T) {
@@ -32,7 +32,7 @@ func TestGetBytesFromHexStringNoValue(t *testing.T) {
 
 	_, err := GetBytesFromHex(md, "test-key")
 
-	assert.Equal(t, status.Newf(codes.InvalidArgument, "missing \"test-key\""), err)
+	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "missing \"test-key\""), err)
 }
 
 func TestGetBytesFromHexStringTooManyValues(t *testing.T) {
@@ -40,7 +40,7 @@ func TestGetBytesFromHexStringTooManyValues(t *testing.T) {
 
 	_, err := GetBytesFromHex(md, "test-key")
 
-	assert.Equal(t, status.Newf(codes.InvalidArgument, "too many values for key \"test-key\": [0x123 FED]"), err)
+	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"test-key\": [0x123 FED]"), err)
 }
 
 func TestGetBigInt(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGetBigIntIncorrectValue(t *testing.T) {
 
 	_, err := GetBigInt(md, "big-int-key")
 
-	assert.Equal(t, status.Newf(codes.InvalidArgument, "incorrect format \"big-int-key\": \"12345abc\""), err)
+	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "incorrect format \"big-int-key\": \"12345abc\""), err)
 }
 
 func TestGetBigIntNoValue(t *testing.T) {
@@ -65,7 +65,7 @@ func TestGetBigIntNoValue(t *testing.T) {
 
 	_, err := GetBigInt(md, "big-int-key")
 
-	assert.Equal(t, status.Newf(codes.InvalidArgument, "missing \"big-int-key\""), err)
+	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "missing \"big-int-key\""), err)
 }
 
 func TestGetBigIntTooManyValues(t *testing.T) {
@@ -73,7 +73,7 @@ func TestGetBigIntTooManyValues(t *testing.T) {
 
 	_, err := GetBigInt(md, "big-int-key")
 
-	assert.Equal(t, status.Newf(codes.InvalidArgument, "too many values for key \"big-int-key\": [12345 54321]"), err)
+	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"big-int-key\": [12345 54321]"), err)
 }
 
 func TestGetBytes(t *testing.T) {
@@ -90,5 +90,5 @@ func TestGetBytesIncorrectBinaryKey(t *testing.T) {
 
 	_, err := GetBytes(md, "binary-key")
 
-	assert.Equal(t, status.Newf(codes.InvalidArgument, "incorrect binary key name \"binary-key\""), err)
+	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "incorrect binary key name \"binary-key\""), err)
 }


### PR DESCRIPTION
Depends on https://github.com/singnet/snet-daemon/pull/162
Fix for issue https://github.com/singnet/snet-daemon/issues/163

What is done:
- new GrpcError type is added to make possible returning more structured information about error from PaymentHandler interface
- custom gRPC error code IncorrectNonce is added to return incorrect nonce error to client
- unit test is added to check that gRPC allows returning custom errors
