### PR TITLE
Use signer to check signature

### DIFF
--- a/blockchain/escrow.go
+++ b/blockchain/escrow.go
@@ -78,6 +78,7 @@ type MultiPartyEscrowChannel struct {
 	Value      *big.Int
 	Nonce      *big.Int
 	Expiration *big.Int
+	Signer     common.Address
 }
 
 var zeroAddress = common.Address{}
@@ -102,6 +103,7 @@ func (processor *Processor) MultiPartyEscrowChannel(channelID *big.Int) (channel
 		Value:      ch.Value,
 		Nonce:      ch.Nonce,
 		Expiration: ch.Expiration,
+		Signer:     ch.Signer,
 	}
 
 	log = log.WithField("channel", channel)

--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -216,6 +216,7 @@ func (payment *paymentTransaction) Commit() error {
 			Recipient:        payment.channel.Recipient,
 			FullAmount:       payment.channel.FullAmount,
 			Expiration:       payment.channel.Expiration,
+			Signer:           payment.channel.Signer,
 			AuthorizedAmount: payment.payment.Amount,
 			Signature:        payment.payment.Signature,
 			GroupID:          payment.channel.GroupID,

--- a/escrow/escrow_test.go
+++ b/escrow/escrow_test.go
@@ -78,7 +78,6 @@ func (transaction *paymentTransactionMock) Rollback() error {
 type PaymentChannelServiceSuite struct {
 	suite.Suite
 
-	senderPrivateKey   *ecdsa.PrivateKey
 	senderAddress      common.Address
 	signerPrivateKey   *ecdsa.PrivateKey
 	signerAddress      common.Address
@@ -92,8 +91,7 @@ type PaymentChannelServiceSuite struct {
 }
 
 func (suite *PaymentChannelServiceSuite) SetupSuite() {
-	suite.senderPrivateKey = GenerateTestPrivateKey()
-	suite.senderAddress = crypto.PubkeyToAddress(suite.senderPrivateKey.PublicKey)
+	suite.senderAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.signerPrivateKey = GenerateTestPrivateKey()
 	suite.signerAddress = crypto.PubkeyToAddress(suite.signerPrivateKey.PublicKey)
 	suite.recipientAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
@@ -156,7 +154,7 @@ func (suite *PaymentChannelServiceSuite) payment() *Payment {
 		ChannelNonce: big.NewInt(3),
 		//MpeContractAddress: suite.mpeContractAddress,
 	}
-	SignTestPayment(payment, suite.senderPrivateKey)
+	SignTestPayment(payment, suite.signerPrivateKey)
 	return payment
 }
 
@@ -205,10 +203,10 @@ func (suite *PaymentChannelServiceSuite) TestPaymentTransaction() {
 func (suite *PaymentChannelServiceSuite) TestPaymentParallelTransaction() {
 	paymentA := suite.payment()
 	paymentA.Amount = big.NewInt(13)
-	SignTestPayment(paymentA, suite.senderPrivateKey)
+	SignTestPayment(paymentA, suite.signerPrivateKey)
 	paymentB := suite.payment()
 	paymentB.Amount = big.NewInt(17)
-	SignTestPayment(paymentB, suite.senderPrivateKey)
+	SignTestPayment(paymentB, suite.signerPrivateKey)
 
 	transactionA, errA := suite.service.StartPaymentTransaction(paymentA)
 	transactionB, errB := suite.service.StartPaymentTransaction(paymentB)
@@ -227,10 +225,10 @@ func (suite *PaymentChannelServiceSuite) TestPaymentParallelTransaction() {
 func (suite *PaymentChannelServiceSuite) TestPaymentSequentialTransaction() {
 	paymentA := suite.payment()
 	paymentA.Amount = big.NewInt(13)
-	SignTestPayment(paymentA, suite.senderPrivateKey)
+	SignTestPayment(paymentA, suite.signerPrivateKey)
 	paymentB := suite.payment()
 	paymentB.Amount = big.NewInt(17)
-	SignTestPayment(paymentB, suite.senderPrivateKey)
+	SignTestPayment(paymentB, suite.signerPrivateKey)
 
 	transactionA, errA := suite.service.StartPaymentTransaction(paymentA)
 	errAC := transactionA.Commit()
@@ -250,10 +248,10 @@ func (suite *PaymentChannelServiceSuite) TestPaymentSequentialTransaction() {
 func (suite *PaymentChannelServiceSuite) TestPaymentSequentialTransactionAfterRollback() {
 	paymentA := suite.payment()
 	paymentA.Amount = big.NewInt(13)
-	SignTestPayment(paymentA, suite.senderPrivateKey)
+	SignTestPayment(paymentA, suite.signerPrivateKey)
 	paymentB := suite.payment()
 	paymentB.Amount = big.NewInt(13)
-	SignTestPayment(paymentB, suite.senderPrivateKey)
+	SignTestPayment(paymentB, suite.signerPrivateKey)
 
 	transactionA, errA := suite.service.StartPaymentTransaction(paymentA)
 	errAC := transactionA.Rollback()

--- a/escrow/escrow_test.go
+++ b/escrow/escrow_test.go
@@ -80,6 +80,8 @@ type PaymentChannelServiceSuite struct {
 
 	senderPrivateKey   *ecdsa.PrivateKey
 	senderAddress      common.Address
+	signerPrivateKey   *ecdsa.PrivateKey
+	signerAddress      common.Address
 	recipientAddress   common.Address
 	mpeContractAddress common.Address
 	memoryStorage      *memoryStorage
@@ -92,6 +94,8 @@ type PaymentChannelServiceSuite struct {
 func (suite *PaymentChannelServiceSuite) SetupSuite() {
 	suite.senderPrivateKey = GenerateTestPrivateKey()
 	suite.senderAddress = crypto.PubkeyToAddress(suite.senderPrivateKey.PublicKey)
+	suite.signerPrivateKey = GenerateTestPrivateKey()
+	suite.signerAddress = crypto.PubkeyToAddress(suite.signerPrivateKey.PublicKey)
 	suite.recipientAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.mpeContractAddress = blockchain.HexToAddress("0xf25186b5081ff5ce73482ad761db0eb0d25abfbf")
 	suite.memoryStorage = NewMemStorage()
@@ -141,6 +145,7 @@ func (suite *PaymentChannelServiceSuite) mpeChannel() *blockchain.MultiPartyEscr
 		Value:      big.NewInt(12345),
 		Nonce:      big.NewInt(3),
 		Expiration: big.NewInt(100),
+		Signer:     suite.signerAddress,
 	}
 }
 
@@ -170,6 +175,7 @@ func (suite *PaymentChannelServiceSuite) channel() *PaymentChannelData {
 		GroupID:          [32]byte{123},
 		FullAmount:       big.NewInt(12345),
 		Expiration:       big.NewInt(100),
+		Signer:           suite.signerAddress,
 		AuthorizedAmount: big.NewInt(0),
 		Signature:        nil,
 	}

--- a/escrow/payment_channel_api.go
+++ b/escrow/payment_channel_api.go
@@ -86,6 +86,9 @@ type PaymentChannelData struct {
 	// expressed in Ethereum block number. Since this block is added to
 	// blockchain Sender can withdraw tokens from channel.
 	Expiration *big.Int
+	// Signer is and address to be used to sign the payments. Usually it is
+	// equal to channel sender.
+	Signer common.Address
 
 	// service provider. This amount increments on price after each successful
 	// RPC call.
@@ -96,8 +99,8 @@ type PaymentChannelData struct {
 }
 
 func (data *PaymentChannelData) String() string {
-	return fmt.Sprintf("{ChannelID: %v, Nonce: %v, State: %v, Sender: %v, Recipient: %v, GroupId: %v, FullAmount: %v, Expiration: %v, AuthorizedAmount: %v, Signature: %v",
-		data.ChannelID, data.Nonce, data.State, blockchain.AddressToHex(&data.Sender), blockchain.AddressToHex(&data.Recipient), data.GroupID, data.FullAmount, data.Expiration, data.AuthorizedAmount, blockchain.BytesToBase64(data.Signature))
+	return fmt.Sprintf("{ChannelID: %v, Nonce: %v, State: %v, Sender: %v, Recipient: %v, GroupId: %v, FullAmount: %v, Expiration: %v, Signer: %v, AuthorizedAmount: %v, Signature: %v",
+		data.ChannelID, data.Nonce, data.State, blockchain.AddressToHex(&data.Sender), blockchain.AddressToHex(&data.Recipient), data.GroupID, data.FullAmount, data.Expiration, data.Signer, data.AuthorizedAmount, blockchain.BytesToBase64(data.Signature))
 }
 
 // PaymentChannelService interface is API for payment channel functionality.

--- a/escrow/payment_channel_storage.go
+++ b/escrow/payment_channel_storage.go
@@ -147,6 +147,7 @@ func (reader *BlockchainChannelReader) GetChannelStateFromBlockchain(key *Paymen
 		GroupID:          ch.GroupId,
 		FullAmount:       ch.Value,
 		Expiration:       ch.Expiration,
+		Signer:           ch.Signer,
 		AuthorizedAmount: big.NewInt(0),
 		Signature:        nil,
 	}, true, nil

--- a/escrow/payment_channel_storage_test.go
+++ b/escrow/payment_channel_storage_test.go
@@ -26,6 +26,7 @@ type PaymentChannelStorageSuite struct {
 	suite.Suite
 
 	senderAddress    common.Address
+	signerAddress    common.Address
 	recipientAddress common.Address
 	memoryStorage    *memoryStorage
 
@@ -34,6 +35,7 @@ type PaymentChannelStorageSuite struct {
 
 func (suite *PaymentChannelStorageSuite) SetupSuite() {
 	suite.senderAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
+	suite.signerAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.recipientAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.memoryStorage = NewMemStorage()
 
@@ -61,6 +63,7 @@ func (suite *PaymentChannelStorageSuite) channel() *PaymentChannelData {
 		GroupID:          [32]byte{123},
 		FullAmount:       big.NewInt(12345),
 		Expiration:       big.NewInt(100),
+		Signer:           suite.signerAddress,
 		AuthorizedAmount: big.NewInt(0),
 		Signature:        nil,
 	}
@@ -83,12 +86,14 @@ type BlockchainChannelReaderSuite struct {
 
 	senderAddress    common.Address
 	recipientAddress common.Address
+	signerAddress    common.Address
 
 	reader BlockchainChannelReader
 }
 
 func (suite *BlockchainChannelReaderSuite) SetupSuite() {
 	suite.senderAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
+	suite.signerAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.recipientAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 
 	suite.reader = BlockchainChannelReader{
@@ -115,6 +120,7 @@ func (suite *BlockchainChannelReaderSuite) mpeChannel() *blockchain.MultiPartyEs
 		Value:      big.NewInt(12345),
 		Nonce:      big.NewInt(3),
 		Expiration: big.NewInt(100),
+		Signer:     suite.signerAddress,
 	}
 }
 
@@ -127,6 +133,7 @@ func (suite *BlockchainChannelReaderSuite) channel() *PaymentChannelData {
 		GroupID:          [32]byte{123},
 		FullAmount:       big.NewInt(12345),
 		Expiration:       big.NewInt(100),
+		Signer:           suite.signerAddress,
 		AuthorizedAmount: big.NewInt(0),
 		Signature:        nil,
 	}

--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -47,8 +47,8 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		return nil, fmt.Errorf("channel is not found, channelId: %v", channelID)
 	}
 
-	if channel.Sender != *sender {
-		return nil, errors.New("only channel sender can get latest channel state")
+	if channel.Signer != *sender {
+		return nil, errors.New("only channel signer can get latest channel state")
 	}
 
 	if channel.Signature == nil {

--- a/escrow/state_service_test.go
+++ b/escrow/state_service_test.go
@@ -13,7 +13,6 @@ import (
 
 type stateServiceTestType struct {
 	service            PaymentChannelStateService
-	senderPrivateKey   *ecdsa.PrivateKey
 	senderAddress      common.Address
 	signerPrivateKey   *ecdsa.PrivateKey
 	signerAddress      common.Address
@@ -28,8 +27,7 @@ type stateServiceTestType struct {
 
 var stateServiceTest = func() stateServiceTestType {
 	channelServiceMock := &paymentChannelServiceMock{}
-	senderPrivateKey := GenerateTestPrivateKey()
-	senderAddress := crypto.PubkeyToAddress(senderPrivateKey.PublicKey)
+	senderAddress := crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	signerPrivateKey := GenerateTestPrivateKey()
 	signerAddress := crypto.PubkeyToAddress(signerPrivateKey.PublicKey)
 
@@ -43,7 +41,6 @@ var stateServiceTest = func() stateServiceTestType {
 		service: PaymentChannelStateService{
 			channelService: channelServiceMock,
 		},
-		senderPrivateKey:   senderPrivateKey,
 		senderAddress:      senderAddress,
 		signerPrivateKey:   signerPrivateKey,
 		signerAddress:      signerAddress,
@@ -61,7 +58,7 @@ var stateServiceTest = func() stateServiceTestType {
 		},
 		defaultRequest: &ChannelStateRequest{
 			ChannelId: bigIntToBytes(defaultChannelId),
-			Signature: getSignature(bigIntToBytes(defaultChannelId), senderPrivateKey),
+			Signature: getSignature(bigIntToBytes(defaultChannelId), signerPrivateKey),
 		},
 		defaultReply: &ChannelStateReply{
 			CurrentNonce:        bigIntToBytes(big.NewInt(3)),
@@ -96,7 +93,7 @@ func TestGetChannelStateChannelIdIsNotPaddedByZero(t *testing.T) {
 		nil,
 		&ChannelStateRequest{
 			ChannelId: []byte{0xFF},
-			Signature: getSignature(bigIntToBytes(channelId), stateServiceTest.senderPrivateKey),
+			Signature: getSignature(bigIntToBytes(channelId), stateServiceTest.signerPrivateKey),
 		},
 	)
 
@@ -135,7 +132,7 @@ func TestGetChannelStateChannelNotFound(t *testing.T) {
 		nil,
 		&ChannelStateRequest{
 			ChannelId: bigIntToBytes(channelId),
-			Signature: getSignature(bigIntToBytes(channelId), stateServiceTest.senderPrivateKey),
+			Signature: getSignature(bigIntToBytes(channelId), stateServiceTest.signerPrivateKey),
 		},
 	)
 
@@ -160,7 +157,7 @@ func TestGetChannelStateIncorrectSender(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, errors.New("only channel sender can get latest channel state"), err)
+	assert.Equal(t, errors.New("only channel signer can get latest channel state"), err)
 	assert.Nil(t, reply)
 }
 

--- a/escrow/state_service_test.go
+++ b/escrow/state_service_test.go
@@ -15,6 +15,8 @@ type stateServiceTestType struct {
 	service            PaymentChannelStateService
 	senderPrivateKey   *ecdsa.PrivateKey
 	senderAddress      common.Address
+	signerPrivateKey   *ecdsa.PrivateKey
+	signerAddress      common.Address
 	channelServiceMock *paymentChannelServiceMock
 
 	defaultChannelId   *big.Int
@@ -28,6 +30,8 @@ var stateServiceTest = func() stateServiceTestType {
 	channelServiceMock := &paymentChannelServiceMock{}
 	senderPrivateKey := GenerateTestPrivateKey()
 	senderAddress := crypto.PubkeyToAddress(senderPrivateKey.PublicKey)
+	signerPrivateKey := GenerateTestPrivateKey()
+	signerAddress := crypto.PubkeyToAddress(signerPrivateKey.PublicKey)
 
 	defaultChannelId := big.NewInt(42)
 	defaultSignature, err := hex.DecodeString("0504030201")
@@ -41,6 +45,8 @@ var stateServiceTest = func() stateServiceTestType {
 		},
 		senderPrivateKey:   senderPrivateKey,
 		senderAddress:      senderAddress,
+		signerPrivateKey:   signerPrivateKey,
+		signerAddress:      signerAddress,
 		channelServiceMock: channelServiceMock,
 
 		defaultChannelId:  defaultChannelId,
@@ -48,6 +54,7 @@ var stateServiceTest = func() stateServiceTestType {
 		defaultChannelData: &PaymentChannelData{
 			ChannelID:        defaultChannelId,
 			Sender:           senderAddress,
+			Signer:           signerAddress,
 			Signature:        defaultSignature,
 			Nonce:            big.NewInt(3),
 			AuthorizedAmount: big.NewInt(12345),

--- a/escrow/validation.go
+++ b/escrow/validation.go
@@ -45,9 +45,9 @@ func (validator *ChannelPaymentValidator) Validate(payment *Payment, channel *Pa
 	}
 
 	log = log.WithField("signerAddress", blockchain.AddressToHex(signerAddress))
-	if *signerAddress != channel.Sender {
-		log.WithField("signerAddress", blockchain.AddressToHex(signerAddress)).Warn("Channel sender is not equal to payment signer")
-		return NewPaymentError(Unauthenticated, "payment is not signed by channel sender")
+	if *signerAddress != channel.Signer {
+		log.WithField("signerAddress", blockchain.AddressToHex(signerAddress)).Warn("Channel signer is not equal to payment signer")
+		return NewPaymentError(Unauthenticated, "payment is not signed by channel signer")
 	}
 	currentBlock, e := validator.currentBlock()
 	if e != nil {

--- a/escrow/validation_test.go
+++ b/escrow/validation_test.go
@@ -61,6 +61,8 @@ type ValidationTestSuite struct {
 
 	senderPrivateKey   *ecdsa.PrivateKey
 	senderAddress      common.Address
+	signerPrivateKey   *ecdsa.PrivateKey
+	signerAddress      common.Address
 	recipientAddress   common.Address
 	mpeContractAddress common.Address
 
@@ -74,6 +76,8 @@ func TestValidationTestSuite(t *testing.T) {
 func (suite *ValidationTestSuite) SetupSuite() {
 	suite.senderPrivateKey = GenerateTestPrivateKey()
 	suite.senderAddress = crypto.PubkeyToAddress(suite.senderPrivateKey.PublicKey)
+	suite.signerPrivateKey = GenerateTestPrivateKey()
+	suite.signerAddress = crypto.PubkeyToAddress(suite.signerPrivateKey.PublicKey)
 	suite.recipientAddress = crypto.PubkeyToAddress(GenerateTestPrivateKey().PublicKey)
 	suite.mpeContractAddress = blockchain.HexToAddress("0xf25186b5081ff5ce73482ad761db0eb0d25abfbf")
 
@@ -103,6 +107,7 @@ func (suite *ValidationTestSuite) channel() *PaymentChannelData {
 		GroupID:          [32]byte{123},
 		FullAmount:       big.NewInt(12345),
 		Expiration:       big.NewInt(100),
+		Signer:           suite.signerAddress,
 		AuthorizedAmount: big.NewInt(12300),
 		Signature:        nil,
 	}


### PR DESCRIPTION
Fix for https://github.com/singnet/snet-daemon/issues/144
Channel sender signature check is replaced by channel signer signature check in payment validation and channel state request authorization.