### PR TITLE
Update daemon configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,96 +119,96 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
-##### DAEMON_ENDPOINT (optional; default: `"127.0.0.1:8080"`)
+##### daemon_endpoint (optional; default: `"127.0.0.1:8080"`)
 Network interface and port which daemon listens to. This parameter should be
 absolutely equal to the corresponding endpoint in the [service configuration
 metadata][service-configuration-metadata]. URI format is recommended:
 http://<host>:<port>.
 
-##### ETHEREUM_JSON_RPC_ENDPOINT (optional, default: `"http://127.0.0.1:8545"`)
+##### ethereum_json_rpc_endpoint (optional, default: `"http://127.0.0.1:8545"`)
 Endpoint to which daemon sends ethereum JSON-RPC requests; recommend
 `"https://kovan.infura.io"` for kovan testnet.
 
-##### IPFS_END_POINT (optional; default `"http://localhost:5002/"`)
+##### ipfs_end_point (optional; default `"http://localhost:5002/"`)
 Endpoint of IPFS instance to get [service configuration
 metadata][service-configuration-metadata]
 
-##### REGISTRY_ADDRESS_KEY (required)
+##### registry_address_key (required)
 Ethereum address of the Registry contract instance.
 
-##### ORGANIZATION_NAME (required)
+##### organization_name (required)
 Name of the organization to search for [service configuration
 metadata][service-configuration-metadata].
 
-##### SERVICE_NAME (required)
+##### service_name (required)
 Name of the service to search for [service configuration
 metadata][service-configuration-metadata].
 
-##### PASSTHROUGH_ENABLED (optional; default: `false`)
+##### passthrough_enabled (optional; default: `false`)
 When passthrough is disabled, daemon echoes requests back as responses; `false`
 reserved mostly for testing purposes.
 
-##### PASSTHROUGH_ENDPOINT (required iff `SERVICE_TYPE` != `executable`)
+##### passthrough_endpoint (required iff `service_type` != `executable`)
 Endpoint to which requests should be proxied for handling by service.
 
-##### EXECUTABLE_PATH (required iff `SERVICE_TYPE` == `executable`)
+##### executable_path (required iff `service_type` == `executable`)
 Path to executable to expose as a service.
 
 #### Other properties
 
 This options are less frequently needed.
 
-##### AUTO_SSL_DOMAIN (optional; default: `""`) 
+##### auto_ssl_domain (optional; default: `""`) 
 Domain name for which the daemon should automatically acquire SSL certs from [Let's Encrypt](https://letsencrypt.org/).
 
-##### AUTO_SSL_CACHE_DIR (optional; only applies if `AUTO_SSL_DOMAIN` is set; default: `".certs"`)
+##### auto_ssl_cache_dir (optional; only applies if `auto_ssl_domain` is set; default: `".certs"`)
 Directory in which to cache the SSL certs issued by Let's Encrypt
 
-##### BLOCKCHAIN_ENABLED (optional; default: `true`)
+##### blockchain_enabled (optional; default: `true`)
 Enables or disables blockchain features of daemon; `false` reserved mostly for testing purposes
 
-##### HDWALLET_INDEX (optional; default: `0`; only applies if `HDWALLET_MNEMONIC` is set)
+##### hdwallet_index (optional; default: `0`; only applies if `hdwallet_mnemonic` is set)
 Derivation index for key to use within HDWallet specified by mnemonic.
 
-##### HDWALLET_MNEMONIC (optional; default: `""`; this or `PRIVATE_KEY` must be set to use `claim` command)
+##### hdwallet_mnemonic (optional; default: `""`; this or `private_key` must be set to use `claim` command)
 [bip39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
 mnemonic corresponding to wallet with which daemon transacts on blockchain.
 
-##### LOG (optional)
+##### log (optional)
 See [logger configuration](./logger/README.md)
 
-##### PRIVATE_KEY (optional; default: `""`; this or `HDWALLET_MNEMONIC` must be set to use `claim` command)
+##### private_key (optional; default: `""`; this or `hdwallet_mnemonic` must be set to use `claim` command)
 Private key with which daemon transacts on blockchain.
 
-##### SSL_CERT (optional; default: `""`)
+##### ssl_cert (optional; default: `""`)
 Path to certificate to use for SSL.
 
-##### SSL_KEY (optional; only applies if `SSL_CERT` is set; default: `""`)
+##### ssl_key (optional; only applies if `ssl_cert` is set; default: `""`)
 Path to key to use for SSL.
 
-##### PAYMENT_CHANNEL_STORAGE_TYPE (optional; default `"etcd"`)
+##### payment_channel_storage_type (optional; default `"etcd"`)
 See [etcd storage type](./etcddb#etcd-storage-type)
 
-##### PAYMENT_CHANNEL_STORAGE_CLIENT (optional)
+##### payment_channel_storage_client (optional)
 See [etcd client configuration](./etcddb#etcd-client-configuration)
 
-##### PAYMENT_CHANNEL_STORAGE_SERVIER (optional)
+##### payment_channel_storage_server (optional)
 See [etcd server configuration](./etcddb#etcd-server-configuration)
 
 #### Environment variables and CLI parameters
 
 |config file key|environment variable name|flag|
 |---|---|---|
-|`AUTO_SSL_DOMAIN`|`SNET_AUTO_SSL_DOMAIN`|`--auto-ssl-domain`|
-|`AUTO_SSL_CACHE_DIR`|`SNET_AUTO_SSL_CACHE_DIR`|`--auto-ssl-cache`|
-|`BLOCKCHAIN_ENABLED`|`SNET_BLOCKCHAIN_ENABLED`|`--blockchain`, `-b`|
-|`CONFIG_PATH`|`SNET_CONFIG_PATH`|`--config`, `-c`|
-|`ETHEREUM_JSON_RPC_ENDPOINT`|`SNET_ETHEREUM_JSON_RPC_ENDPOINT`|`--ethereum-endpoint`|
-|`HDWALLET_INDEX`|`SNET_HDWALLET_INDEX`|`--wallet-index`|
-|`HDWALLET_MNEMONIC`|`SNET_HDWALLET_MNEMONIC`|`--mnemonic`|
-|`PASSTHROUGH_ENABLED`|`SNET_PASSTHROUGH_ENABLED`|`--passthrough`|
-|`SSL_CERT`|`SNET_SSL_CERT`|`--ssl-cert`|
-|`SSL_KEY`|`SNET_SSL_KEY`|`--ssl-key`|
+|`auto_ssl_domain`|`SNET_AUTO_SSL_DOMAIN`|`--auto-ssl-domain`|
+|`auto_ssl_cache_dir`|`SNET_AUTO_SSL_CACHE_DIR`|`--auto-ssl-cache`|
+|`blockchain_enabled`|`SNET_BLOCKCHAIN_ENABLED`|`--blockchain`, `-b`|
+|`config_path`|`SNET_CONFIG_PATH`|`--config`, `-c`|
+|`ethereum_json_rpc_endpoint`|`SNET_ETHEREUM_JSON_RPC_ENDPOINT`|`--ethereum-endpoint`|
+|`hdwallet_index`|`SNET_HDWALLET_INDEX`|`--wallet-index`|
+|`hdwallet_mnemonic`|`SNET_HDWALLET_MNEMONIC`|`--mnemonic`|
+|`passthrough_enabled`|`SNET_PASSTHROUGH_ENABLED`|`--passthrough`|
+|`ssl_cert`|`SNET_SSL_CERT`|`--ssl-cert`|
+|`ssl_key`|`SNET_SSL_KEY`|`--ssl-key`|
 
 [service-configuration-metadata]: https://github.com/singnet/wiki/blob/master/multiPartyEscrowContract/MPEServiceMetadata.md
 

--- a/README.md
+++ b/README.md
@@ -114,76 +114,85 @@ also supported via [Viper](https://github.com/spf13/viper). Use `snet init`
 command to save configuration file with default values. Following
 configuration properties can be set using configuration file.
 
-#### AUTO_SSL_DOMAIN (optional; default: `""`) 
-Domain name for which the daemon should automatically acquire SSL certs from [Let's Encrypt](https://letsencrypt.org/).
+#### Main properties
 
-#### AUTO_SSL_CACHE_DIR (optional; only applies if `AUTO_SSL_DOMAIN` is set; default: `".certs"`)
-Directory in which to cache the SSL certs issued by Let's Encrypt
+These properties you should usually change before starting daemon for the first
+time.
 
-#### BLOCKCHAIN_ENABLED (optional; default: `true`)
-Enables or disables blockchain features of daemon; `false` reserved mostly for testing purposes
-
-#### DAEMON_ENDPOINT (required)
+##### DAEMON_ENDPOINT (optional; default: `"127.0.0.1:8080"`)
 Network interface and port which daemon listens to. This parameter should be
 absolutely equal to the corresponding endpoint in the [service configuration
 metadata][service-configuration-metadata]. URI format is recommended:
 http://<host>:<port>.
 
-#### ETHEREUM_JSON_RPC_ENDPOINT (required)
+##### ETHEREUM_JSON_RPC_ENDPOINT (optional, default: `"http://127.0.0.1:8545"`)
 Endpoint to which daemon sends ethereum JSON-RPC requests; recommend
 `"https://kovan.infura.io"` for kovan testnet.
 
-#### EXECUTABLE_PATH (required iff `SERVICE_TYPE` == `executable`)
-Path to executable to expose as a service.
-
-#### HDWALLET_INDEX (optional; default: `0`; only applies if `HDWALLET_MNEMONIC` is set)
-Derivation index for key to use within HDWallet specified by mnemonic.
-
-#### HDWALLET_MNEMONIC (optional; default: `""`; this or `PRIVATE_KEY` must be set to use `claim` command)
-[bip39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
-mnemonic corresponding to wallet with which daemon transacts on blockchain.
-
-#### IPFS_END_POINT (optional; default `"http://localhost:5002/"`)
+##### IPFS_END_POINT (optional; default `"http://localhost:5002/"`)
 Endpoint of IPFS instance to get [service configuration
 metadata][service-configuration-metadata]
 
-#### LOG (optional)
-See [logger configuration](./logger/README.md)
-
-#### REGISTRY_ADDRESS_KEY (required)
+##### REGISTRY_ADDRESS_KEY (required)
 Ethereum address of the Registry contract instance.
 
-#### ORGANIZATION_NAME (required)
+##### ORGANIZATION_NAME (required)
 Name of the organization to search for [service configuration
 metadata][service-configuration-metadata].
 
-#### SERVICE_NAME (required)
+##### SERVICE_NAME (required)
 Name of the service to search for [service configuration
 metadata][service-configuration-metadata].
 
-#### PASSTHROUGH_ENABLED (optional; default: `false`)
+##### PASSTHROUGH_ENABLED (optional; default: `false`)
 When passthrough is disabled, daemon echoes requests back as responses; `false`
 reserved mostly for testing purposes.
 
-#### PASSTHROUGH_ENDPOINT (required iff `SERVICE_TYPE` != `executable`)
+##### PASSTHROUGH_ENDPOINT (required iff `SERVICE_TYPE` != `executable`)
 Endpoint to which requests should be proxied for handling by service.
 
-#### PRIVATE_KEY (optional; default: `""`; this or `HDWALLET_MNEMONIC` must be set to use `claim` command)
+##### EXECUTABLE_PATH (required iff `SERVICE_TYPE` == `executable`)
+Path to executable to expose as a service.
+
+#### Other properties
+
+This options are less frequently needed.
+
+##### AUTO_SSL_DOMAIN (optional; default: `""`) 
+Domain name for which the daemon should automatically acquire SSL certs from [Let's Encrypt](https://letsencrypt.org/).
+
+##### AUTO_SSL_CACHE_DIR (optional; only applies if `AUTO_SSL_DOMAIN` is set; default: `".certs"`)
+Directory in which to cache the SSL certs issued by Let's Encrypt
+
+##### BLOCKCHAIN_ENABLED (optional; default: `true`)
+Enables or disables blockchain features of daemon; `false` reserved mostly for testing purposes
+
+##### HDWALLET_INDEX (optional; default: `0`; only applies if `HDWALLET_MNEMONIC` is set)
+Derivation index for key to use within HDWallet specified by mnemonic.
+
+##### HDWALLET_MNEMONIC (optional; default: `""`; this or `PRIVATE_KEY` must be set to use `claim` command)
+[bip39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+mnemonic corresponding to wallet with which daemon transacts on blockchain.
+
+##### LOG (optional)
+See [logger configuration](./logger/README.md)
+
+##### PRIVATE_KEY (optional; default: `""`; this or `HDWALLET_MNEMONIC` must be set to use `claim` command)
 Private key with which daemon transacts on blockchain.
 
-#### SSL_CERT (optional; default: `""`)
+##### SSL_CERT (optional; default: `""`)
 Path to certificate to use for SSL.
 
-#### SSL_KEY (optional; only applies if `SSL_CERT` is set; default: `""`)
+##### SSL_KEY (optional; only applies if `SSL_CERT` is set; default: `""`)
 Path to key to use for SSL.
 
-#### PAYMENT_CHANNEL_STORAGE_TYPE (optional; default `"etcd"`)
+##### PAYMENT_CHANNEL_STORAGE_TYPE (optional; default `"etcd"`)
 See [etcd storage type](./etcddb#etcd-storage-type)
 
-#### PAYMENT_CHANNEL_STORAGE_CLIENT (optional)
+##### PAYMENT_CHANNEL_STORAGE_CLIENT (optional)
 See [etcd client configuration](./etcddb#etcd-client-configuration)
 
-#### PAYMENT_CHANNEL_STORAGE_SERVIER (optional)
+##### PAYMENT_CHANNEL_STORAGE_SERVIER (optional)
 See [etcd server configuration](./etcddb#etcd-server-configuration)
 
 #### Environment variables and CLI parameters

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ ./scripts/test
 
 Configuration file is a main source of the configuration. Some properties
 can be set via environment variables or command line parameters see [table
-below](environment-variables-and-cli-parameters). Use `--config`
+below](#environment-variables-and-cli-parameters). Use `--config`
 parameter with any command to set configuration file name.  By default daemon
 use configuration file in JSON format `snetd.config.json` but other formats are
 also supported via [Viper](https://github.com/spf13/viper). Use `snet init`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,103 @@ $ ./scripts/test
 
 ### Configuration
 
-* [logger configuration](./logger/README.md)
+Configuration file is a main source of the configuration. Some properties
+can be set via environment variables or command line parameters see [table
+below](environment-variables-and-cli-parameters). Use `--config`
+parameter with any command to set configuration file name.  By default daemon
+use configuration file in JSON format `snetd.config.json` but other formats are
+also supported via [Viper](https://github.com/spf13/viper). Use `snet init`
+command to save configuration file with default values. Following
+configuration properties can be set using configuration file.
+
+#### AUTO_SSL_DOMAIN (optional; default: `""`) 
+Domain name for which the daemon should automatically acquire SSL certs from [Let's Encrypt](https://letsencrypt.org/).
+
+#### AUTO_SSL_CACHE_DIR (optional; only applies if `AUTO_SSL_DOMAIN` is set; default: `".certs"`)
+Directory in which to cache the SSL certs issued by Let's Encrypt
+
+#### BLOCKCHAIN_ENABLED (optional; default: `true`)
+Enables or disables blockchain features of daemon; `false` reserved mostly for testing purposes
+
+#### DAEMON_ENDPOINT (required)
+Network interface and port which daemon listens to. This parameter should be
+absolutely equal to the corresponding endpoint in the [service configuration
+metadata][service-configuration-metadata]. URI format is recommended:
+http://<host>:<port>.
+
+#### ETHEREUM_JSON_RPC_ENDPOINT (required)
+Endpoint to which daemon sends ethereum JSON-RPC requests; recommend
+`"https://kovan.infura.io"` for kovan testnet.
+
+#### EXECUTABLE_PATH (required iff `SERVICE_TYPE` == `executable`)
+Path to executable to expose as a service.
+
+#### HDWALLET_INDEX (optional; default: `0`; only applies if `HDWALLET_MNEMONIC` is set)
+Derivation index for key to use within HDWallet specified by mnemonic.
+
+#### HDWALLET_MNEMONIC (optional; default: `""`; this or `PRIVATE_KEY` must be set to use `claim` command)
+[bip39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+mnemonic corresponding to wallet with which daemon transacts on blockchain.
+
+#### IPFS_END_POINT (optional; default `"http://localhost:5002/"`)
+Endpoint of IPFS instance to get [service configuration
+metadata][service-configuration-metadata]
+
+#### LOG (optional)
+See [logger configuration](./logger/README.md)
+
+#### REGISTRY_ADDRESS_KEY (required)
+Ethereum address of the Registry contract instance.
+
+#### ORGANIZATION_NAME (required)
+Name of the organization to search for [service configuration
+metadata][service-configuration-metadata].
+
+#### SERVICE_NAME (required)
+Name of the service to search for [service configuration
+metadata][service-configuration-metadata].
+
+#### PASSTHROUGH_ENABLED (optional; default: `false`)
+When passthrough is disabled, daemon echoes requests back as responses; `false`
+reserved mostly for testing purposes.
+
+#### PASSTHROUGH_ENDPOINT (required iff `SERVICE_TYPE` != `executable`)
+Endpoint to which requests should be proxied for handling by service.
+
+#### PRIVATE_KEY (optional; default: `""`; this or `HDWALLET_MNEMONIC` must be set to use `claim` command)
+Private key with which daemon transacts on blockchain.
+
+#### SSL_CERT (optional; default: `""`)
+Path to certificate to use for SSL.
+
+#### SSL_KEY (optional; only applies if `SSL_CERT` is set; default: `""`)
+Path to key to use for SSL.
+
+#### PAYMENT_CHANNEL_STORAGE_TYPE (optional; default `"etcd"`)
+See [etcd storage type](./etcddb#etcd-storage-type)
+
+#### PAYMENT_CHANNEL_STORAGE_CLIENT (optional)
+See [etcd client configuration](./etcddb#etcd-client-configuration)
+
+#### PAYMENT_CHANNEL_STORAGE_SERVIER (optional)
+See [etcd server configuration](./etcddb#etcd-server-configuration)
+
+#### Environment variables and CLI parameters
+
+|config file key|environment variable name|flag|
+|---|---|---|
+|`AUTO_SSL_DOMAIN`|`SNET_AUTO_SSL_DOMAIN`|`--auto-ssl-domain`|
+|`AUTO_SSL_CACHE_DIR`|`SNET_AUTO_SSL_CACHE_DIR`|`--auto-ssl-cache`|
+|`BLOCKCHAIN_ENABLED`|`SNET_BLOCKCHAIN_ENABLED`|`--blockchain`, `-b`|
+|`CONFIG_PATH`|`SNET_CONFIG_PATH`|`--config`, `-c`|
+|`ETHEREUM_JSON_RPC_ENDPOINT`|`SNET_ETHEREUM_JSON_RPC_ENDPOINT`|`--ethereum-endpoint`|
+|`HDWALLET_INDEX`|`SNET_HDWALLET_INDEX`|`--wallet-index`|
+|`HDWALLET_MNEMONIC`|`SNET_HDWALLET_MNEMONIC`|`--mnemonic`|
+|`PASSTHROUGH_ENABLED`|`SNET_PASSTHROUGH_ENABLED`|`--passthrough`|
+|`SSL_CERT`|`SNET_SSL_CERT`|`--ssl-cert`|
+|`SSL_KEY`|`SNET_SSL_KEY`|`--ssl-key`|
+
+[service-configuration-metadata]: https://github.com/singnet/wiki/blob/master/multiPartyEscrowContract/MPEServiceMetadata.md
 
 ## Release
 
@@ -120,3 +216,4 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 This project is licensed under the MIT License - see the
 [LICENSE](https://github.com/singnet/snet-daemon/blob/master/LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -119,81 +119,81 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
-##### daemon_endpoint (optional; default: `"127.0.0.1:8080"`)
-Network interface and port which daemon listens to. This parameter should be
+* **daemon_endpoint** (optional; default: `"127.0.0.1:8080"`) - 
+network interface and port which daemon listens to. This parameter should be
 absolutely equal to the corresponding endpoint in the [service configuration
 metadata][service-configuration-metadata]. URI format is recommended:
 http://<host>:<port>.
 
-##### ethereum_json_rpc_endpoint (optional, default: `"http://127.0.0.1:8545"`)
-Endpoint to which daemon sends ethereum JSON-RPC requests; recommend
+* **ethereum_json_rpc_endpoint** (optional, default: `"http://127.0.0.1:8545"`) -
+endpoint to which daemon sends ethereum JSON-RPC requests; recommend
 `"https://kovan.infura.io"` for kovan testnet.
 
-##### ipfs_end_point (optional; default `"http://localhost:5002/"`)
-Endpoint of IPFS instance to get [service configuration
+* **ipfs_end_point** (optional; default `"http://localhost:5002/"`) - 
+endpoint of IPFS instance to get [service configuration
 metadata][service-configuration-metadata]
 
-##### registry_address_key (required)
+* **registry_address_key** (required) - 
 Ethereum address of the Registry contract instance.
 
-##### organization_name (required)
-Name of the organization to search for [service configuration
+* **organization_name** (required) - 
+name of the organization to search for [service configuration
 metadata][service-configuration-metadata].
 
-##### service_name (required)
-Name of the service to search for [service configuration
+* **service_name** (required) - 
+name of the service to search for [service configuration
 metadata][service-configuration-metadata].
 
-##### passthrough_enabled (optional; default: `false`)
-When passthrough is disabled, daemon echoes requests back as responses; `false`
+* **passthrough_enabled** (optional; default: `false`) - 
+when passthrough is disabled, daemon echoes requests back as responses; `false`
 reserved mostly for testing purposes.
 
-##### passthrough_endpoint (required iff `service_type` != `executable`)
-Endpoint to which requests should be proxied for handling by service.
+* **passthrough_endpoint** (required iff `service_type` != `executable`) - 
+endpoint to which requests should be proxied for handling by service.
 
-##### executable_path (required iff `service_type` == `executable`)
-Path to executable to expose as a service.
+* **executable_path** (required iff `service_type` == `executable`) - 
+path to executable to expose as a service.
 
 #### Other properties
 
 This options are less frequently needed.
 
-##### auto_ssl_domain (optional; default: `""`) 
-Domain name for which the daemon should automatically acquire SSL certs from [Let's Encrypt](https://letsencrypt.org/).
+* **auto_ssl_domain** (optional; default: `""`) -  
+domain name for which the daemon should automatically acquire SSL certs from [Let's Encrypt](https://letsencrypt.org/).
 
-##### auto_ssl_cache_dir (optional; only applies if `auto_ssl_domain` is set; default: `".certs"`)
-Directory in which to cache the SSL certs issued by Let's Encrypt
+* **auto_ssl_cache_dir** (optional; only applies if `auto_ssl_domain` is set; default: `".certs"`) - 
+directory in which to cache the SSL certs issued by Let's Encrypt
 
-##### blockchain_enabled (optional; default: `true`)
-Enables or disables blockchain features of daemon; `false` reserved mostly for testing purposes
+* **blockchain_enabled** (optional; default: `true`) - 
+enables or disables blockchain features of daemon; `false` reserved mostly for testing purposes
 
-##### hdwallet_index (optional; default: `0`; only applies if `hdwallet_mnemonic` is set)
-Derivation index for key to use within HDWallet specified by mnemonic.
+* **hdwallet_index** (optional; default: `0`; only applies if `hdwallet_mnemonic` is set) - 
+derivation index for key to use within HDWallet specified by mnemonic.
 
-##### hdwallet_mnemonic (optional; default: `""`; this or `private_key` must be set to use `claim` command)
+* **hdwallet_mnemonic** (optional; default: `""`; this or `private_key` must be set to use `claim` command) - 
 [bip39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
 mnemonic corresponding to wallet with which daemon transacts on blockchain.
 
-##### log (optional)
-See [logger configuration](./logger/README.md)
+* **private_key** (optional; default: `""`; this or `hdwallet_mnemonic` must be set to use `claim` command) - 
+private key with which daemon transacts on blockchain.
 
-##### private_key (optional; default: `""`; this or `hdwallet_mnemonic` must be set to use `claim` command)
-Private key with which daemon transacts on blockchain.
+* **log** (optional) - 
+see [logger configuration](./logger/README.md)
 
-##### ssl_cert (optional; default: `""`)
-Path to certificate to use for SSL.
+* **ssl_cert** (optional; default: `""`) - 
+path to certificate to use for SSL.
 
-##### ssl_key (optional; only applies if `ssl_cert` is set; default: `""`)
-Path to key to use for SSL.
+* **ssl_key** (optional; only applies if `ssl_cert` is set; default: `""`) - 
+path to key to use for SSL.
 
-##### payment_channel_storage_type (optional; default `"etcd"`)
-See [etcd storage type](./etcddb#etcd-storage-type)
+* **payment_channel_storage_type** (optional; default `"etcd"`) - 
+see [etcd storage type](./etcddb#etcd-storage-type)
 
-##### payment_channel_storage_client (optional)
-See [etcd client configuration](./etcddb#etcd-client-configuration)
+* **payment_channel_storage_client** (optional) - 
+see [etcd client configuration](./etcddb#etcd-client-configuration)
 
-##### payment_channel_storage_server (optional)
-See [etcd server configuration](./etcddb#etcd-server-configuration)
+* **payment_channel_storage_server** (optional) - 
+see [etcd server configuration](./etcddb#etcd-server-configuration)
 
 #### Environment variables and CLI parameters
 

--- a/config/config.go
+++ b/config/config.go
@@ -42,8 +42,8 @@ const (
 	defaultConfigJson string = `
 {
 	"auto_ssl_domain": "",
+	"auto_ssl_cache_dir": ".certs",
 	"blockchain_enabled": true,
-	"daemon_listening_port": 8080,
 	"daemon_type": "grpc",
 	"daemon_end_point": "127.0.0.1:8080",
 	"ethereum_json_rpc_endpoint": "http://127.0.0.1:8545",
@@ -54,6 +54,7 @@ const (
 	"passthrough_enabled": false,
 	"registry_address_key": "0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2",
 	"service_name": "ExampleService", 
+	"private_key": "",
 	"ssl_cert": "",
 	"ssl_key": "",
 	"log":  {

--- a/config/config.go
+++ b/config/config.go
@@ -14,30 +14,30 @@ import (
 )
 
 const (
-	RegistryAddressKey   = "REGISTRY_ADDRESS_KEY" //to be read from github
-	AutoSSLDomainKey     = "AUTO_SSL_DOMAIN"
-	AutoSSLCacheDirKey   = "AUTO_SSL_CACHE_DIR"
-	BlockchainEnabledKey = "BLOCKCHAIN_ENABLED"
-	ConfigPathKey        = "CONFIG_PATH"
+	RegistryAddressKey   = "registry_address_key" //to be read from github
+	AutoSSLDomainKey     = "auto_ssl_domain"
+	AutoSSLCacheDirKey   = "auto_ssl_cache_dir"
+	BlockchainEnabledKey = "blockchain_enabled"
+	ConfigPathKey        = "config_path"
 
-	DaemonTypeKey                  = "DAEMON_TYPE"
-	DaemonEndPoint                 = "DAEMON_END_POINT"
-	EthereumJsonRpcEndpointKey     = "ETHEREUM_JSON_RPC_ENDPOINT"
-	ExecutablePathKey              = "EXECUTABLE_PATH"
-	HdwalletIndexKey               = "HDWALLET_INDEX"
-	HdwalletMnemonicKey            = "HDWALLET_MNEMONIC"
-	IpfsEndPoint                   = "IPFS_END_POINT"
-	LogKey                         = "LOG"
-	OrganizationName               = "ORGANIZATION_NAME"
-	ServiceName                    = "SERVICE_NAME"
-	PassthroughEnabledKey          = "PASSTHROUGH_ENABLED"
-	PassthroughEndpointKey         = "PASSTHROUGH_ENDPOINT"
-	PrivateKeyKey                  = "PRIVATE_KEY"
-	SSLCertPathKey                 = "SSL_CERT"
-	SSLKeyPathKey                  = "SSL_KEY"
-	PaymentChannelStorageTypeKey   = "PAYMENT_CHANNEL_STORAGE_TYPE"
-	PaymentChannelStorageClientKey = "PAYMENT_CHANNEL_STORAGE_CLIENT"
-	PaymentChannelStorageServerKey = "PAYMENT_CHANNEL_STORAGE_SERVER"
+	DaemonTypeKey                  = "daemon_type"
+	DaemonEndPoint                 = "daemon_end_point"
+	EthereumJsonRpcEndpointKey     = "ethereum_json_rpc_endpoint"
+	ExecutablePathKey              = "executable_path"
+	HdwalletIndexKey               = "hdwallet_index"
+	HdwalletMnemonicKey            = "hdwallet_mnemonic"
+	IpfsEndPoint                   = "ipfs_end_point"
+	LogKey                         = "log"
+	OrganizationName               = "organization_name"
+	ServiceName                    = "service_name"
+	PassthroughEnabledKey          = "passthrough_enabled"
+	PassthroughEndpointKey         = "passthrough_endpoint"
+	PrivateKeyKey                  = "private_key"
+	SSLCertPathKey                 = "ssl_cert"
+	SSLKeyPathKey                  = "ssl_key"
+	PaymentChannelStorageTypeKey   = "payment_channel_storage_type"
+	PaymentChannelStorageClientKey = "payment_channel_storage_client"
+	PaymentChannelStorageServerKey = "payment_channel_storage_server"
 
 	defaultConfigJson string = `
 {

--- a/logger/README.md
+++ b/logger/README.md
@@ -87,9 +87,30 @@ call [NewMailAuthHook method](https://godoc.org/github.com/zbindenren/logrus_mai
 * username
 * password
 
+Resulting log configuration using logrus_mail hook:
+```json
+  "log": {
+    ...
+    "hooks": [ "send-mail" ],
+    "send-mail": {
+      "type": "mail_auth",
+      "levels": ["Error", "Warn"],
+      "config": {
+		"application_name": "test-application-name",
+		"host": "smtp.gmail.com",
+		"port": 587,
+		"from": "from-user@gmail.com",
+		"to": "to-user@gmail.com",
+		"username": "smtp-username",
+		"password": "secret"
+	  }
+    },
+  }
+```
+
 # Default logger configuration in JSON format
 
-```
+```json
   "log": {
     "level": "info",
     "timezone": "UTC",

--- a/logger/README.md
+++ b/logger/README.md
@@ -5,99 +5,79 @@ library. Logger configuration is a set of properties started from ```log.```
 prefix. If configuration file is formatted using JSON then all logger
 configuration is one JSON object located in ```log``` field.
 
-# log
+* **log** - log configuration section
 
-## log.level (default: info)
+  * **level** (default: info) - log level. Possible values are
+    [logrus](https://github.com/sirupsen/logrus) log levels
+    * debug
+    * info
+    * warn
+    * error
+    * fatal
+    * panic
 
-Log level. Possible values are [logrus](https://github.com/sirupsen/logrus) log
-levels
-* debug
-* info
-* warn
-* error
-* fatal
-* panic
+  * **timezone** (default: UTC) - timezone to format timestamps and log
+    file names. It should be name of the time.Location, see
+    [time.LoadLocation](https://golang.org/pkg/time/#LoadLocation).
 
-## log.timezone (default: UTC)
+  * **formatter** - set of properties with ```log.formatter.``` prefix
+    describes logger formatter configuration.
 
-Timezone to format timestamps and log file names. It should be name of the
-time.Location, see
-[time.LoadLocation](https://golang.org/pkg/time/#LoadLocation).
+    * **type** (default: json) - type of the log formatter. Two types are
+      supported, which correspond to ```logrus``` formatter types, see [logrus
+      Formatter](https://github.com/sirupsen/logrus#formatters)
+      * json
+      * text
 
-## log.formatter
+  * **output** - set of properties with ```log.output.``` prefix describes
+    logger output configuration.
 
-Set of properties with ```log.formatter.``` prefix describes logger formatter
-configuration.
+    * **type** (default: file) - type of the logger output. Two types are
+      supported:
+      * file -
+        [file-rotatelogs](https://github.com/lestrrat-go/file-rotatelogs)
+        output which supports log rotation
+      * stdout - os.Stdout
 
-### log.formatter.type (default: json)
+    * **file_pattern** (default: ./snet-daemon.%Y%m%d.log) - log file name
+      which may include date/time patterns in ```strftime (3)``` format. Time
+      and date in file name are necessary to support log rotation.
 
-Type of the log formatter. Two types are supported, which correspond to
-```logrus``` formatter types, see [logrus
-Formatter](https://github.com/sirupsen/logrus#formatters)
-* json
-* text
+    * **current_link** (default: ./snet-daemon.log) - link to the latest log
+      file.
 
-## log.output
+    * **rotation_time_in_sec** (default: 86400 (1 day)) - number of seconds
+      before log rotation happens.
 
-Set of properties with ```log.output.``` prefix describes logger output
-configuration.
+    * **max_age_in_sec** (default: 604800 (1 week)) - number of seconds since
+      last modification time before log file is removed.
 
-### log.output.type (default: file)
+    * **rotation_count** (default: 0 (disabled)) - max number of rotation
+      files. When number of log files becomes greater then oldest log file is
+      removed.
 
-Type of the logger output. Two types are supported:
-* file - [file-rotatelogs](https://github.com/lestrrat-go/file-rotatelogs)
-  output which supports log rotation
-* stdout - os.Stdout
+  * **hooks** (default: []) - list of names of the hooks which will be executed
+    when message with specified log level appears in log. See [logrus
+    hooks](https://github.com/sirupsen/logrus#hooks). List contains names of
+    the hooks and hook configuration can be found by name prefix.  Thus for
+    hook named ```<hook-name>``` properties will start from
+    ```log.<hook-name>.``` prefix.
 
-### log.output.file_pattern (default: ./snet-daemon.%Y%m%d.log)
+  * **```<hook-name>```** - configuration of log hook with `<hook-name>` name
 
-Log file name which may include date/time patterns in ```strftime (3)```
-format. Time and date in file name are necessary to support log rotation.
+    * **type** (required) - Type of the hook. this type is used to find actual
+      hook implementation. Hook types supported:
+      * mail_auth - [logrus_mail](https://github.com/zbindenren/logrus_mail)
 
-### log.output.current_link (default: ./snet-daemon.log)
+    * **levels** (required) - list of log levels to trigger the hook. 
 
-Link to the latest log file.
+    * **config** (depends on hook implementation) - set of properties with
+      ```log.<hook-name>.config``` prefix are passed to the hook implementation
+      when it is initialized. This list of properties is hook specific.
 
-### log.output.rotation_time_in_sec (default: 86400 (1 day))
+## logrus_mail hook config
 
-Number of seconds before log rotation happens.
-
-### log.output.max_age_in_sec (default: 604800 (1 week))
-
-Number of seconds since last modification time before log file is removed.
-
-### log.output.rotation_count (default: 0 (disabled))
-
-Max number of rotation files. When number of log files becomes greater then
-oldest log file is removed.
-
-## log.hooks (default: [])
-
-List of names of the hooks which will be executed when message with specified
-log level appears in log. See [logrus
-hooks](https://github.com/sirupsen/logrus#hooks). List contains names of the
-hooks and hook configuration can be found by name prefix.  Thus for hook named
-```<hook-name>``` properties will start from ```log.<hook-name>.``` prefix.
-
-### log.\<hook-name\>.type (required)
-
-Type of the hook. This type is used to find actual hook implementation. Hook
-types supported:
-* mail_auth - [logrus_mail](https://github.com/zbindenren/logrus_mail)
-
-### log.\<hook-name\>.levels (required)
-
-List of log levels to trigger the hook. 
-
-### log.\<hook-name\>.config (depends on hook implementation)
-
-Set of properties with ```log.<hook-name>.config``` prefix are passed to the
-hook implementation when it is initialized. This list of properties is hook
-specific.
-
-### logrus_mail hook
-
-Its configuration should contains all of the properties which are required to
+Its configuration should contain all of the properties which are required to
 call [NewMailAuthHook method](https://godoc.org/github.com/zbindenren/logrus_mail#NewMailAuthHook)
 * application_name
 * host


### PR DESCRIPTION
Update snet-daemon configuration documentation to fix https://github.com/singnet/snet-daemon/issues/151
and unblock https://github.com/singnet/wiki/issues/32.

what is done:
- documentation updated
- property names are converted to the same case (lowcase)
- defaults for ```private_key```  and ```auto_ssl_cache_dir``` properties are added
- legacy ```daemon_listening_port``` property is removed