### PR TITLE
check hash of files from IPFS (fix for issue #176)

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,3 +69,7 @@
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "1.2.0"
+
+[[constraint]]
+  name = "github.com/ipfs/go-ipfs-api"
+  branch = "master"

--- a/ipfsutils/ipfsutils.go
+++ b/ipfsutils/ipfsutils.go
@@ -30,10 +30,10 @@ func GetIpfsFile(hash string) string {
 	//validating the file read from IPFS
 	newHash, err := sh.Add(strings.NewReader(jsondata), shell.OnlyHash(true))
 	if err != nil {
-		log.WithError(err).Panic("error: in generating IPFS hash for the meta data file %v", err)
+		log.WithError(err).Panic("error in generating the hash for the meta data read from IPFS : %v", err)
 	}
 	if newHash != hash {
-		log.WithError(err).WithField("hashFromIPFS", newHash).
+		log.WithError(err).WithField("hashFromIPFSContent", newHash).
 			Panic("IPFS hash verification failed. Generated hash doesnt match with expected hash %s", hash)
 	}
 

--- a/ipfsutils/ipfsutils.go
+++ b/ipfsutils/ipfsutils.go
@@ -5,6 +5,7 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	"strings"
 )
 
 func GetIpfsFile(hash string) string {
@@ -25,6 +26,16 @@ func GetIpfsFile(hash string) string {
 	log.WithField("hash", hash).WithField("blob", string(blob)).Debug("Blob of IPFS file with hash")
 
 	jsondata := string(blob)
+
+	//validating the file read from IPFS
+	newHash, err := sh.Add(strings.NewReader(jsondata), shell.OnlyHash(true))
+	if err != nil {
+		log.WithError(err).Panic("error: in generating IPFS hash for the meta data file %v", err)
+	}
+	if newHash != hash {
+		log.WithError(err).WithField("hashFromIPFS", newHash).
+			Panic("IPFS hash verification failed. Generated hash doesnt match with expected hash %s", hash)
+	}
 
 	cid.Close()
 	return jsondata


### PR DESCRIPTION
@astroseger @vsbogd @raamb @anandrgit 
this fix involves generating the IPFS multihash from the IPFS provided metadata and validate against the requested IPFS metadata using Hash. Both generated and requested hashes must match to consider the metadata is valid and secure.

Can you review the fix and provide your comments 