### PR TITLE
fix for issue when Daemon hangs if no service metadata in IPFS (issue #170)

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,3 +69,7 @@
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "1.2.0"
+
+[[constraint]]
+  name = "github.com/ipfs/go-ipfs-api"
+  branch = "master"

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ see [rate limiting configuration](./ratelimit/README.md)
 
 * **heartbeat_svc_end_point** (optional; default: `""`) - It must be a valid URL. if it is empty, then service state always assumed as SERVING, and same will be wrapped in Daemon Heartbeat. see [daemon heartbeats configuration](./metrics/README.md)
 
+* **ipfs_timeout** (optional; default: `30`) - All IPFS read/writes timeout if the operations doesnt complete in 30 sec or set duration in this config entry.
 
 #### Environment variables and CLI parameters
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ const (
 	HdwalletIndexKey               = "hdwallet_index"
 	HdwalletMnemonicKey            = "hdwallet_mnemonic"
 	IpfsEndPoint                   = "ipfs_end_point"
+	IpfsTimeout                    = "ipfs_timeout"
 	LogKey                         = "log"
 	MonitoringEnabled              = "monitoring_enabled"
 	MonitoringServiceEndpoint      = "monitoring_svc_end_point"
@@ -62,6 +63,7 @@ const (
 	"hdwallet_index": 0,
 	"hdwallet_mnemonic": "",
 	"ipfs_end_point": "http://localhost:5002/", 
+	"ipfs_timeout" : 30,
 	"monitoring_enabled": true,
 	"monitoring_svc_end_point": "https://n4rzw9pu76.execute-api.us-east-1.amazonaws.com/beta",
 	"organization_id": "ExampleOrganizationId", 

--- a/ipfsutils/ipfsutils.go
+++ b/ipfsutils/ipfsutils.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"strings"
+	"time"
 )
 
 func GetIpfsFile(hash string) string {
@@ -43,5 +44,7 @@ func GetIpfsFile(hash string) string {
 
 func GetIpfsShell() *shell.Shell {
 	sh := shell.NewShell(config.GetString(config.IpfsEndPoint))
+	// sets the timeout for accessing the ipfs content
+	sh.SetTimeout(time.Duration(config.GetInt(config.IpfsTimeout)) * time.Second)
 	return sh
 }

--- a/ipfsutils/ipfsutils.go
+++ b/ipfsutils/ipfsutils.go
@@ -30,10 +30,10 @@ func GetIpfsFile(hash string) string {
 	//validating the file read from IPFS
 	newHash, err := sh.Add(strings.NewReader(jsondata), shell.OnlyHash(true))
 	if err != nil {
-		log.WithError(err).Panic("error: in generating IPFS hash for the meta data file %v", err)
+		log.WithError(err).Panic("error in generating the hash for the meta data read from IPFS : %v", err)
 	}
 	if newHash != hash {
-		log.WithError(err).WithField("hashFromIPFS", newHash).
+		log.WithError(err).WithField("hashFromIPFSContent", newHash).
 			Panic("IPFS hash verification failed. Generated hash doesnt match with expected hash %s", hash)
 	}
 

--- a/ipfsutils/ipfsutils.go
+++ b/ipfsutils/ipfsutils.go
@@ -5,6 +5,7 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	"strings"
 )
 
 func GetIpfsFile(hash string) string {
@@ -25,6 +26,16 @@ func GetIpfsFile(hash string) string {
 	log.WithField("hash", hash).WithField("blob", string(blob)).Debug("Blob of IPFS file with hash")
 
 	jsondata := string(blob)
+
+	//validating the file read from IPFS
+	newHash, err := sh.Add(strings.NewReader(jsondata), shell.OnlyHash(true))
+	if err != nil {
+		log.WithError(err).Panic("error: in generating IPFS hash for the meta data file %v", err)
+	}
+	if newHash != hash {
+		log.WithError(err).WithField("hashFromIPFS", newHash).
+			Panic("IPFS hash verification failed. Generated hash doesnt match with expected hash %s", hash)
+	}
 
 	cid.Close()
 	return jsondata


### PR DESCRIPTION
@vsbogd @raamb @anandrgit 
By default, IPFS reads/writes has time out for more than a minute. If there is no file found in IPFS, then the shell keeps waiting for the file until timeout occurs, during which daemon looks hanged. 
A configurable timeout has been added (defaulted to 30 sec) to Daemon to control the timeout duration to reduce effects of empty IPFS or non existence of files in IPFS. if in case of a real empty IPFS file  returned, then unmarshalling to metadata fails and eventually daemon will not run anymore.

Please review and let us know you comments/suggestions.