### PR TITLE
Increase the limit of the maximum message size for the server to be 4GB

### DIFF
--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -200,7 +200,8 @@ func (d daemon) start() {
 	}
 
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
-		maxsizeOpt := grpc.MaxRecvMsgSize(1000000000) //1GB
+		// set the maximum that the server can receive to 4GB. It is set to for 4GB because of issue here https://github.com/grpc/grpc-go/issues/1590
+		maxsizeOpt := grpc.MaxRecvMsgSize(4000000000)
 		d.grpcServer = grpc.NewServer(
 			grpc.UnknownServiceHandler(handler.NewGrpcHandler(d.components.ServiceMetaData())),
 			grpc.StreamInterceptor(d.components.GrpcInterceptor()),

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -200,9 +200,11 @@ func (d daemon) start() {
 	}
 
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
+		maxsizeOpt := grpc.MaxRecvMsgSize(1000000000) //1GB
 		d.grpcServer = grpc.NewServer(
 			grpc.UnknownServiceHandler(handler.NewGrpcHandler(d.components.ServiceMetaData())),
 			grpc.StreamInterceptor(d.components.GrpcInterceptor()),
+			maxsizeOpt,
 		)
 		escrow.RegisterPaymentChannelStateServiceServer(d.grpcServer, d.components.PaymentChannelStateService())
 


### PR DESCRIPTION
The default message size in gRPC is 4MB. However as mentioned in #185, there is a possibility of the message size sent to services being more than the default limit. The maximum message size can be in the range of `int64` but this will be capped at `int32` for 32-bit systems. Hence, I set the maximum size to be 4GB. 
Please refer to this [issue](https://github.com/grpc/grpc-go/issues/1590) on the main **grpc-go** repo.