### PR TITLE
Issue #175 : Auto determine the address of the Registry based on the Network Selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,22 +138,21 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
+
+* **blockchain_network_selected** (required; default: `"local"`) - 
+Name of the network to be used for Daemon possible values are one of (kovan,ropsten,main,local or rinkeby).
+Daemon will automatically read the Registry address associated with this network
+For local network ( you can also specify the registry address manually),see the blockchain_network_config.json
+
 * **daemon_endpoint** (optional; default: `"127.0.0.1:8080"`) - 
 network interface and port which daemon listens to. This parameter should be
 absolutely equal to the corresponding endpoint in the [service configuration
 metadata][service-configuration-metadata]. URI format is recommended:
 http://<host>:<port>.
 
-* **ethereum_json_rpc_endpoint** (optional, default: `"http://127.0.0.1:8545"`) -
-endpoint to which daemon sends ethereum JSON-RPC requests; recommend
-`"https://kovan.infura.io"` for kovan testnet.
-
 * **ipfs_end_point** (optional; default `"http://localhost:5002/"`) - 
 endpoint of IPFS instance to get [service configuration
 metadata][service-configuration-metadata]
-
-* **registry_address_key** (required) - 
-Ethereum address of the Registry contract instance.
 
 * **organization_id** (required) - 
 Id of the organization to search for [service configuration

--- a/blockchain/ethereumClient.go
+++ b/blockchain/ethereumClient.go
@@ -15,7 +15,7 @@ type EthereumClient struct {
 func GetEthereumClient() (*EthereumClient, error) {
 
 	ethereumClient := new(EthereumClient)
-	if client, err := rpc.Dial(config.GetString(config.EthereumJsonRpcEndpointKey)); err != nil {
+	if client, err := rpc.Dial(config.GetBlockChainEndPoint()); err != nil {
 		return nil, errors.Wrap(err, "error creating RPC client")
 	} else {
 		ethereumClient.RawClient = client

--- a/blockchain/serviceMetadata.go
+++ b/blockchain/serviceMetadata.go
@@ -45,7 +45,7 @@ type ServiceMetadata struct {
 }
 
 func getRegistryAddressKey() common.Address {
-	address := config.GetString(config.RegistryAddressKey)
+	address := config.GetRegistryAddress()
 	return common.HexToAddress(address)
 }
 

--- a/blockchain_network_config.json
+++ b/blockchain_network_config.json
@@ -1,0 +1,23 @@
+{
+  "local":{
+    "ethereum_json_rpc_endpoint":"http://localhost:8545",
+    "network_id":"42",
+    "registry_address_key":"0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2"
+  },
+  "kovan":{
+    "ethereum_json_rpc_endpoint":"https://kovan.infura.io",
+    "network_id":"42"
+  },
+  "ropsten":{
+    "ethereum_json_rpc_endpoint":"https://ropsten.infura.io",
+    "network_id":"3"
+  },
+  "rinkeby":{
+    "ethereum_json_rpc_endpoint":"https://rinkeby.infura.io",
+    "network_id":"7"
+  },
+  "main":{
+    "ethereum_json_rpc_endpoint":"https://mainnet.infura.io",
+    "network_id":"1"
+  }
+}

--- a/blockchain_network_config.json
+++ b/blockchain_network_config.json
@@ -1,7 +1,7 @@
 {
   "local":{
     "ethereum_json_rpc_endpoint":"http://localhost:8545",
-    "network_id":"42",
+    "network_id":"999999",
     "registry_address_key":"0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2"
   },
   "kovan":{
@@ -14,7 +14,7 @@
   },
   "rinkeby":{
     "ethereum_json_rpc_endpoint":"https://rinkeby.infura.io",
-    "network_id":"7"
+    "network_id":"4"
   },
   "main":{
     "ethereum_json_rpc_endpoint":"https://mainnet.infura.io",

--- a/config/blockchain_network_config.go
+++ b/config/blockchain_network_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 )
 
@@ -54,7 +55,8 @@ func determineNetworkSelected(data []byte) {
 	networkName := GetString(BlockChainNetworkSelected)
 	err := json.Unmarshal(data, &dynamicBinding)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("cannot parse the JSON configuation file %v for the network %v  to determine the network selected: %v",
+			BlockChainNetworkFileName, GetString(BlockChainNetworkSelected), err))
 	}
 	networkSelected = &NetworkSelected{
 		//Get the Network Name selected in config ( snetd.config.json) , Based on this retrieve the Registry address ,
@@ -102,7 +104,7 @@ func setRegistryAddress() {
 		panic(fmt.Sprintf("cannot find the file at %v for the network %v configuation file to read the address config: %v",
 			RegistryJsonFileName, GetString(BlockChainNetworkSelected), err))
 	}
-	networkSelected.RegistryAddressKey= getRegistryAddressFromJson(data)
+	networkSelected.RegistryAddressKey = getRegistryAddressFromJson(data)
 }
 
 func getRegistryAddressFromJson(data []byte) string {
@@ -126,11 +128,13 @@ func ReadFromFile(filename string) ([]byte, error) {
 }
 
 //Read from the block chain network config json
-func setBlockChainNetworkDetails() {
+func setAndValidateBlockChainNetworkDetails() {
 	data, err := ReadFromFile(BlockChainNetworkFileName)
 	if err != nil {
 		data = []byte(DefaultBlockChainNetworkConfig)
 	}
 	determineNetworkSelected(data)
 	setRegistryAddress()
+	log.Infof("blockchain_network_selected: %v BlockChainNetwork Registry Address:%v  Ethereum end point:%v ",
+		GetString(BlockChainNetworkSelected), GetRegistryAddress(), GetBlockChainEndPoint())
 }

--- a/config/blockchain_network_config.go
+++ b/config/blockchain_network_config.go
@@ -19,7 +19,7 @@ const (
 {
   "local":{
     "ethereum_json_rpc_endpoint":"http://localhost:8545",
-    "network_id":"42",
+    "network_id":"999999",
     "registry_address_key":"0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2"
   },
   "kovan":{
@@ -32,7 +32,7 @@ const (
   },
   "rinkeby":{
     "ethereum_json_rpc_endpoint":"https://rinkeby.infura.io",
-    "network_id":"7"
+    "network_id":"4"
   },
   "main":{
     "ethereum_json_rpc_endpoint":"https://mainnet.infura.io",
@@ -48,7 +48,6 @@ const (
 )
 
 var networkSelected *NetworkSelected
-
 
 func determineNetworkSelected(data []byte) {
 	dynamicBinding := map[string]interface{}{}
@@ -66,45 +65,54 @@ func determineNetworkSelected(data []byte) {
 		NetworkId:               fmt.Sprintf("%v", dynamicBinding[networkName].(map[string]interface{})[NetworkId]),
 	}
 }
+
 //Check if the Registry address was set in the block chain network config, then we use this address as the contract address
 //the address is usually set for local testing , for other network types like ropsten or kovan or main , the system will automatically
 //figure out the contract address
-func getRegistryAddressfromJSON(address interface{} ) string {
+func getRegistryAddressfromJSON(address interface{}) string {
 	if address == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v",address)
+	return fmt.Sprintf("%v", address)
 }
+
 //Get the Network ID associated  with the network selected
 func GetNetworkId() (string) {
 	return networkSelected.NetworkId
 }
+
 //Get the block chain end point associated with the Network selected
 func GetBlockChainEndPoint() string {
 	return networkSelected.EthereumJSONRPCEndpoint
 }
+
 //Get the Registry address of the contract
 func GetRegistryAddress() string {
 	return networkSelected.RegistryAddressKey
 }
+
 //Read the Registry address from JSON file ( file will be under networks folder)
 func setRegistryAddress() {
 	//if address is already set in the config file and has been initialized , then skip the setting process
-	if len(networkSelected.RegistryAddressKey)>0 {
+	if len(networkSelected.RegistryAddressKey) > 0 {
 		return
 	}
 	data, err := ReadFromFile(RegistryJsonFileName)
 	if err != nil {
 		panic(fmt.Sprintf("cannot find the file at %v for the network %v configuation file to read the address config: %v",
-			RegistryJsonFileName,GetString(BlockChainNetworkSelected),err))
+			RegistryJsonFileName, GetString(BlockChainNetworkSelected), err))
 	}
+	networkSelected.RegistryAddressKey= getRegistryAddressFromJson(data)
+}
+
+func getRegistryAddressFromJson(data []byte) string {
 	m := map[string]interface{}{}
-	err = json.Unmarshal(data, &m)
+	err := json.Unmarshal(data, &m)
 	if err != nil {
 		panic(fmt.Sprintf("cannot parse the JSON file at %v for the %v configuation file to read the address config: %v",
-			RegistryJsonFileName,GetString(BlockChainNetworkSelected),err))
+			RegistryJsonFileName, GetString(BlockChainNetworkSelected), err))
 	}
-	networkSelected.RegistryAddressKey = fmt.Sprintf("%v", m[GetNetworkId()].(map[string]interface{})["address"])
+	return fmt.Sprintf("%v", m[GetNetworkId()].(map[string]interface{})["address"])
 }
 
 //Read the file given file, if the file is not found  ,then return back an error
@@ -116,6 +124,7 @@ func ReadFromFile(filename string) ([]byte, error) {
 	return file, nil
 
 }
+
 //Read from the block chain network config json
 func setBlockChainNetworkDetails() {
 	data, err := ReadFromFile(BlockChainNetworkFileName)

--- a/config/blockchain_network_config.go
+++ b/config/blockchain_network_config.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io/ioutil"
+)
+
+type NetworkSelected struct {
+	NetworkName             string
+	EthereumJSONRPCEndpoint string
+	NetworkId               string
+	RegistryAddressKey      string
+}
+
+const (
+	DefaultBlockChainNetworkConfig string = `
+{
+  "local":{
+    "ethereum_json_rpc_endpoint":"http://localhost:8545",
+    "network_id":"42",
+    "registry_address_key":"0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2"
+  },
+  "kovan":{
+    "ethereum_json_rpc_endpoint":"https://kovan.infura.io",
+    "network_id":"42"
+  },
+  "ropsten":{
+    "ethereum_json_rpc_endpoint":"https://ropsten.infura.io",
+    "network_id":"3"
+  },
+  "rinkeby":{
+    "ethereum_json_rpc_endpoint":"https://rinkeby.infura.io",
+    "network_id":"7"
+  },
+  "main":{
+    "ethereum_json_rpc_endpoint":"https://mainnet.infura.io",
+    "network_id":"1"
+  }
+}`
+	BlockChainNetworkFileName  = "blockchain_network_config.json"
+	EthereumJsonRpcEndpointKey = "ethereum_json_rpc_endpoint"
+	NetworkId                  = "network_id"
+	RegistryAddressKey         = "registry_address_key"
+	//Read this from a config file path todo
+	RegistryJsonFileName = "resources/blockchain/node_modules/singularitynet-platform-contracts/networks/Registry.json"
+)
+
+var networkSelected *NetworkSelected
+
+
+func determineNetworkSelected(data []byte) {
+	dynamicBinding := map[string]interface{}{}
+	networkName := GetString(BlockChainNetworkSelected)
+	err := json.Unmarshal(data, &dynamicBinding)
+	if err != nil {
+		panic(err)
+	}
+	networkSelected = &NetworkSelected{
+		//Get the Network Name selected in config ( snetd.config.json) , Based on this retrieve the Registry address ,
+		//Ethereum End point and Network ID mapped
+		NetworkName:             networkName,
+		RegistryAddressKey:      getRegistryAddressfromJSON(dynamicBinding[networkName].(map[string]interface{})[RegistryAddressKey]),
+		EthereumJSONRPCEndpoint: fmt.Sprintf("%v", dynamicBinding[networkName].(map[string]interface{})[EthereumJsonRpcEndpointKey]),
+		NetworkId:               fmt.Sprintf("%v", dynamicBinding[networkName].(map[string]interface{})[NetworkId]),
+	}
+}
+//Check if the Registry address was set in the block chain network config, then we use this address as the contract address
+//the address is usually set for local testing , for other network types like ropsten or kovan or main , the system will automatically
+//figure out the contract address
+func getRegistryAddressfromJSON(address interface{} ) string {
+	if address == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v",address)
+}
+//Get the Network ID associated  with the network selected
+func GetNetworkId() (string) {
+	return networkSelected.NetworkId
+}
+//Get the block chain end point associated with the Network selected
+func GetBlockChainEndPoint() string {
+	return networkSelected.EthereumJSONRPCEndpoint
+}
+//Get the Registry address of the contract
+func GetRegistryAddress() string {
+	return networkSelected.RegistryAddressKey
+}
+//Read the Registry address from JSON file ( file will be under networks folder)
+func setRegistryAddress() {
+	//if address is already set in the config file and has been initialized , then skip the setting process
+	if len(networkSelected.RegistryAddressKey)>0 {
+		return
+	}
+	data, err := ReadFromFile(RegistryJsonFileName)
+	if err != nil {
+		panic(fmt.Sprintf("cannot find the file at %v for the network %v configuation file to read the address config: %v",
+			RegistryJsonFileName,GetString(BlockChainNetworkSelected),err))
+	}
+	m := map[string]interface{}{}
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		panic(fmt.Sprintf("cannot parse the JSON file at %v for the %v configuation file to read the address config: %v",
+			RegistryJsonFileName,GetString(BlockChainNetworkSelected),err))
+	}
+	networkSelected.RegistryAddressKey = fmt.Sprintf("%v", m[GetNetworkId()].(map[string]interface{})["address"])
+}
+
+//Read the file given file, if the file is not found  ,then return back an error
+func ReadFromFile(filename string) ([]byte, error) {
+	file, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not read file: %v", filename)
+	}
+	return file, nil
+
+}
+//Read from the block chain network config json
+func setBlockChainNetworkDetails() {
+	data, err := ReadFromFile(BlockChainNetworkFileName)
+	if err != nil {
+		data = []byte(DefaultBlockChainNetworkConfig)
+	}
+	determineNetworkSelected(data)
+	setRegistryAddress()
+}

--- a/config/blockchain_network_config_test.go
+++ b/config/blockchain_network_config_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"github.com/magiconair/properties/assert"
+	assert2 "github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetNetworkId(t *testing.T) {
+
+	//assert2.NotEqual(t,err,nil)
+}
+
+
+func TestGetBlockChainEndPoint(t *testing.T) {
+	determineNetworkSelected([]byte(DefaultBlockChainNetworkConfig))
+	assert.Matches(t,GetBlockChainEndPoint(),GetString(BlockChainNetworkSelected))
+	assert2.NotEqual(t,GetNetworkId(),nil)
+	assert2.NotEqual(t,GetRegistryAddress(),"")
+}
+
+
+func TestGetRegistryAddress(t *testing.T) {
+	determineNetworkSelected([]byte(DefaultBlockChainNetworkConfig))
+	if GetString(BlockChainNetworkSelected) == "local" {
+		assert2.NotEqual(t, GetRegistryAddress(), "")
+	} else {
+		assert2.NotEqual(t, GetRegistryAddress(), nil)
+	}
+}
+

--- a/config/blockchain_network_config_test.go
+++ b/config/blockchain_network_config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGetRegistryAddress(t *testing.T) {
-	setBlockChainNetworkDetails()
+	setAndValidateBlockChainNetworkDetails()
 	assert2.NotEqual(t,GetRegistryAddress(),nil)
 }
 

--- a/config/blockchain_network_config_test.go
+++ b/config/blockchain_network_config_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestGetNetworkId(t *testing.T) {
-
-	//assert2.NotEqual(t,err,nil)
+func TestGetRegistryAddress(t *testing.T) {
+	setBlockChainNetworkDetails()
+	assert2.NotEqual(t,GetRegistryAddress(),nil)
 }
 
 
@@ -20,12 +20,24 @@ func TestGetBlockChainEndPoint(t *testing.T) {
 }
 
 
-func TestGetRegistryAddress(t *testing.T) {
+func TestDetermineNetworkSelected(t *testing.T) {
 	determineNetworkSelected([]byte(DefaultBlockChainNetworkConfig))
 	if GetString(BlockChainNetworkSelected) == "local" {
 		assert2.NotEqual(t, GetRegistryAddress(), "")
 	} else {
 		assert2.NotEqual(t, GetRegistryAddress(), nil)
 	}
+}
+
+func TestReadFromFile(t *testing.T) {
+	data,err:=ReadFromFile("../blockchain_network_config.json")
+	assert2.NotEqual(t,data,nil)
+	assert.Equal(t,err,nil)
+}
+
+func TestGetRegistryAddressFromJson (t *testing.T) {
+
+	address := getRegistryAddressFromJson([]byte("{\"999999\":{\"events\":{},\"links\":{},\"address\":\"0xe331bf20044a5b24c1a744abc90c1fd711d2c08d\",\"transactionHash\":\"0xb98bcff3cfd65916b50f85f3bb89c83252b24b74f42ede4c4badd2456cf2bf9a\"}}"))
+	assert.Equal(t,address,"0xe331bf20044a5b24c1a744abc90c1fd711d2c08d")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ const (
 	AutoSSLDomainKey     = "auto_ssl_domain"
 	AutoSSLCacheDirKey   = "auto_ssl_cache_dir"
 	BlockchainEnabledKey = "blockchain_enabled"
-	BlockChainNetworkSelected       = "blockchain_network_selected"
+	BlockChainNetworkSelected      = "blockchain_network_selected"
 	BurstSize            = "burst_size"
 	ConfigPathKey        = "config_path"
 
@@ -171,7 +171,8 @@ func Validate() error {
 		!IsValidUrl(vip.GetString(MonitoringServiceEndpoint)) {
 		return errors.New("service endpoint must be a valid URL")
 	}
-
+	//Set all the block chain network details after config has been initialized with values.
+	setAndValidateBlockChainNetworkDetails()
 	// Validate metrics URL and set state
 	return nil
 }
@@ -221,8 +222,6 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	for subKey, value := range subMap {
 		sub.Set(subKey, value)
 	}
-	//Set all the block chain network details after config has been initialized with values.
-	setBlockChainNetworkDetails()
 	return sub
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,16 +16,16 @@ import (
 )
 
 const (
-	RegistryAddressKey   = "registry_address_key" //to be read from github
 	AutoSSLDomainKey     = "auto_ssl_domain"
 	AutoSSLCacheDirKey   = "auto_ssl_cache_dir"
 	BlockchainEnabledKey = "blockchain_enabled"
+	BlockChainNetworkSelected       = "blockchain_network_selected"
 	BurstSize            = "burst_size"
 	ConfigPathKey        = "config_path"
 
 	DaemonTypeKey                  = "daemon_type"
 	DaemonEndPoint                 = "daemon_end_point"
-	EthereumJsonRpcEndpointKey     = "ethereum_json_rpc_endpoint"
+
 	ExecutablePathKey              = "executable_path"
 	HdwalletIndexKey               = "hdwallet_index"
 	HdwalletMnemonicKey            = "hdwallet_mnemonic"
@@ -57,9 +57,9 @@ const (
 	"auto_ssl_domain": "",
 	"auto_ssl_cache_dir": ".certs",
 	"blockchain_enabled": true,
+	"blockchain_network_selected": "local",
 	"daemon_type": "grpc",
 	"daemon_end_point": "127.0.0.1:8080",
-	"ethereum_json_rpc_endpoint": "http://127.0.0.1:8545",
 	"hdwallet_index": 0,
 	"hdwallet_mnemonic": "",
 	"ipfs_end_point": "http://localhost:5002/", 
@@ -68,7 +68,6 @@ const (
 	"monitoring_svc_end_point": "https://n4rzw9pu76.execute-api.us-east-1.amazonaws.com/beta",
 	"organization_id": "ExampleOrganizationId", 
 	"passthrough_enabled": false,
-	"registry_address_key": "0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2",
 	"service_id": "ExampleServiceId", 
 	"private_key": "",
 	"ssl_cert": "",
@@ -131,7 +130,6 @@ func init() {
 		panic(fmt.Sprintf("Cannot load default config: %v", err))
 	}
 	SetDefaultFromConfig(vip, defaults)
-
 	vip.AddConfigPath(".")
 }
 
@@ -223,7 +221,8 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	for subKey, value := range subMap {
 		sub.Set(subKey, value)
 	}
-
+	//Set all the block chain network details after config has been initialized with values.
+	setBlockChainNetworkDetails()
 	return sub
 }
 


### PR DESCRIPTION
Based on the network selected ( kovan /ropsten/local/main)  , we identify the network ID it is mapped to , using this network ID , the registry address will be read from the networks/Registry.json file .
With this change we get away from manually setting the registry and the ethereum end point in the daemon configuration.( snetd.config.json)

Take Registry address from platform-contracts by default. beta
#175 