### PR TITLE
Channel lock Issue #172 ( income % does not equal to price % )

### DIFF
--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -60,14 +60,14 @@ func (h *paymentChannelPaymentHandler) Payment(context *handler.GrpcStreamContex
 
 	transaction, e := h.service.StartPaymentTransaction(internalPayment)
 	if e != nil {
-		return nil, paymentErrorToGrpcError(e)
+		return transaction, paymentErrorToGrpcError(e)
 	}
 
 	income := big.NewInt(0)
 	income.Sub(internalPayment.Amount, transaction.Channel().AuthorizedAmount)
 	e = h.incomeValidator.Validate(&IncomeData{Income: income, GrpcContext: context})
 	if e != nil {
-		return nil, paymentErrorToGrpcError(e)
+		return transaction, paymentErrorToGrpcError(e)
 	}
 
 	return transaction, nil

--- a/escrow/payment_handler_test.go
+++ b/escrow/payment_handler_test.go
@@ -141,5 +141,5 @@ func (suite *PaymentHandlerTestSuite) TestValidatePaymentIncorrectIncome() {
 	payment, err := paymentHandler.Payment(context)
 
 	assert.Equal(suite.T(), handler.NewGrpcError(codes.Unauthenticated, "incorrect payment income: \"45\", expected \"46\""), err)
-	assert.Nil(suite.T(), payment)
+	assert.NotEqual(suite.T(), payment, nil)
 }


### PR DESCRIPTION
Once you hit the error "income % does not equal to price % ", the channel will get locked as the rollback wasn't happening.

This change is to fix it , details of the fix are below
1) define the defer function call well before the first return on an error ( else the defer function doesnt get called)
Since the Rollback is handled at centralized place () intercept ,
2) make sure the transactions on the method called are is returned even if there is an error ( else the rollback will not happen and the lock is set on the channel)
Also related to singnet#172
singnet#172