### PR TITLE
Channel gets locked when you see "income % does not equal to price % ", error Issue #172

### DIFF
--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -67,6 +67,8 @@ func (h *paymentChannelPaymentHandler) Payment(context *handler.GrpcStreamContex
 	income.Sub(internalPayment.Amount, transaction.Channel().AuthorizedAmount)
 	e = h.incomeValidator.Validate(&IncomeData{Income: income, GrpcContext: context})
 	if e != nil {
+		//Make sure the transaction is Rolled back , else this will cause a lock on the channel
+		transaction.Rollback()
 		return nil, paymentErrorToGrpcError(e)
 	}
 


### PR DESCRIPTION
Once you hit the error "income % does not equal to price % ", the channel will get locked
Ensure that Rollback() is done in such a scenario
Also related to singnet#172
