### PR TITLE
Channel lock cleanup test

### DIFF
--- a/escrow/state_service.proto
+++ b/escrow/state_service.proto
@@ -1,3 +1,9 @@
+//
+// FIXME: All changes all this file should manually be copied to the `snet-cli`
+// repo until https://github.com/singnet/snet-daemon/issues/99 and
+// https://github.com/singnet/snet-cli/issues/88 are fixed.
+//
+
 syntax = "proto3";
 
 package escrow;

--- a/handler/interceptors.go
+++ b/handler/interceptors.go
@@ -170,8 +170,8 @@ func (interceptor *paymentValidationInterceptor) intercept(srv interface{}, ss g
 	defer func() {
 		if !handlerSucceed {
 			if r := recover(); r != nil {
-				e = r.(error)
-				paymentHandler.CompleteAfterError(payment, e)
+				log.WithField("panicValue", r).Warn("Service handler called panic(panicValue)")
+				paymentHandler.CompleteAfterError(payment, fmt.Errorf("Service handler called panic(%v)", r))
 				panic("re-panic after payment handler error handling")
 			} else if e != nil {
 				err = paymentHandler.CompleteAfterError(payment, e)

--- a/handler/interceptors_test.go
+++ b/handler/interceptors_test.go
@@ -5,90 +5,102 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 )
 
-func TestGetBytesFromHexString(t *testing.T) {
+type InterceptorsSuite struct {
+	suite.Suite
+}
+
+func (suite *InterceptorsSuite) SetupSuite() {
+}
+
+func TestIntersecptorsSuite(t *testing.T) {
+	suite.Run(t, new(InterceptorsSuite))
+}
+
+func (suite *InterceptorsSuite) TestGetBytesFromHexString() {
 	md := metadata.Pairs("test-key", "0xfFfE0100")
 
 	bytes, err := GetBytesFromHex(md, "test-key")
 
-	assert.Nil(t, err)
-	assert.Equal(t, []byte{255, 254, 1, 0}, bytes)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []byte{255, 254, 1, 0}, bytes)
 }
 
-func TestGetBytesFromHexStringNoPrefix(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBytesFromHexStringNoPrefix() {
 	md := metadata.Pairs("test-key", "fFfE0100")
 
 	bytes, err := GetBytesFromHex(md, "test-key")
 
-	assert.Nil(t, err)
-	assert.Equal(t, []byte{255, 254, 1, 0}, bytes)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []byte{255, 254, 1, 0}, bytes)
 }
 
-func TestGetBytesFromHexStringNoValue(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBytesFromHexStringNoValue() {
 	md := metadata.Pairs("unknown-key", "fFfE0100")
 
 	_, err := GetBytesFromHex(md, "test-key")
 
-	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "missing \"test-key\""), err)
+	assert.Equal(suite.T(), NewGrpcErrorf(codes.InvalidArgument, "missing \"test-key\""), err)
 }
 
-func TestGetBytesFromHexStringTooManyValues(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBytesFromHexStringTooManyValues() {
 	md := metadata.Pairs("test-key", "0x123", "test-key", "FED")
 
 	_, err := GetBytesFromHex(md, "test-key")
 
-	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"test-key\": [0x123 FED]"), err)
+	assert.Equal(suite.T(), NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"test-key\": [0x123 FED]"), err)
 }
 
-func TestGetBigInt(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBigInt() {
 	md := metadata.Pairs("big-int-key", "12345")
 
 	value, err := GetBigInt(md, "big-int-key")
 
-	assert.Nil(t, err)
-	assert.Equal(t, big.NewInt(12345), value)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), big.NewInt(12345), value)
 }
 
-func TestGetBigIntIncorrectValue(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBigIntIncorrectValue() {
 	md := metadata.Pairs("big-int-key", "12345abc")
 
 	_, err := GetBigInt(md, "big-int-key")
 
-	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "incorrect format \"big-int-key\": \"12345abc\""), err)
+	assert.Equal(suite.T(), NewGrpcErrorf(codes.InvalidArgument, "incorrect format \"big-int-key\": \"12345abc\""), err)
 }
 
-func TestGetBigIntNoValue(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBigIntNoValue() {
 	md := metadata.Pairs()
 
 	_, err := GetBigInt(md, "big-int-key")
 
-	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "missing \"big-int-key\""), err)
+	assert.Equal(suite.T(), NewGrpcErrorf(codes.InvalidArgument, "missing \"big-int-key\""), err)
 }
 
-func TestGetBigIntTooManyValues(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBigIntTooManyValues() {
 	md := metadata.Pairs("big-int-key", "12345", "big-int-key", "54321")
 
 	_, err := GetBigInt(md, "big-int-key")
 
-	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"big-int-key\": [12345 54321]"), err)
+	assert.Equal(suite.T(), NewGrpcErrorf(codes.InvalidArgument, "too many values for key \"big-int-key\": [12345 54321]"), err)
 }
 
-func TestGetBytes(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBytes() {
 	md := metadata.Pairs("binary-key-bin", string([]byte{0x00, 0x01, 0xFE, 0xFF}))
 
 	value, err := GetBytes(md, "binary-key-bin")
 
-	assert.Nil(t, err)
-	assert.Equal(t, []byte{0, 1, 254, 255}, value)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []byte{0, 1, 254, 255}, value)
 }
 
-func TestGetBytesIncorrectBinaryKey(t *testing.T) {
+func (suite *InterceptorsSuite) TestGetBytesIncorrectBinaryKey() {
 	md := metadata.Pairs("binary-key", string([]byte{0x00, 0x01, 0xFE, 0xFF}))
 
 	_, err := GetBytes(md, "binary-key")
 
-	assert.Equal(t, NewGrpcErrorf(codes.InvalidArgument, "incorrect binary key name \"binary-key\""), err)
+	assert.Equal(suite.T(), NewGrpcErrorf(codes.InvalidArgument, "incorrect binary key name \"binary-key\""), err)
 }


### PR DESCRIPTION
This is to close issue https://github.com/singnet/snet-daemon/issues/145

Convert unit tests to test suite. Add unit tests for error handling. Fix panic type conversion issue.

Better review by commits, last two are most significant:
- https://github.com/singnet/snet-daemon/pull/194/commits/2b330f3b3fd61d394ed864ba56c3869fc67a54b8
- https://github.com/singnet/snet-daemon/pull/194/commits/17eec17f08ae66b404d3c65da09bbe12f29555e0