### PR TITLE
Issue #199  Behind NAT support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
-* **daemon_endpoint** (optional; default: `"127.0.0.1:8080"`) - 
-network interface and port which daemon listens to. This parameter should be
-absolutely equal to the corresponding endpoint in the [service configuration
-metadata][service-configuration-metadata]. URI format is recommended:
-http://<host>:<port>.
+* **daemon_group_name** (required ,default: `"default_group"`) - 
+This parameter defines the group the daemon belongs to .
+The group helps determine the recipient address for payments.
+[service configuration
+metadata][service-configuration-metadata]. 
 
 * **ethereum_json_rpc_endpoint** (optional, default: `"http://127.0.0.1:8545"`) -
 endpoint to which daemon sends ethereum JSON-RPC requests; recommend
@@ -189,6 +189,9 @@ enables or disables blockchain features of daemon; `false` reserved mostly for t
 
 * **burst_size** (optional; default: Infinite) - 
 see [rate limiting configuration](./ratelimit/README.md)
+
+* **daemon_listening_port** (optional; default: `"8080"`) - 
+Defines the port on which the daemon listens to.
 
 * **hdwallet_index** (optional; default: `0`; only applies if `hdwallet_mnemonic` is set) - 
 derivation index for key to use within HDWallet specified by mnemonic.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
+* **daemon_end_point** (mandatory; default: `"0.0.0.0:8080"`) - 
+Defines the ip and the port on which the daemon listens to.
+format is :`<host>:<port>`.
 
 * **ethereum_json_rpc_endpoint** (optional, default: `"http://127.0.0.1:8545"`) -
 endpoint to which daemon sends ethereum JSON-RPC requests; recommend
@@ -190,9 +193,6 @@ This parameter defines the group the daemon belongs to .
 The group helps determine the recipient address for payments.
 [service configuration
 metadata][service-configuration-metadata]. 
-
-* **daemon_listening_port** (optional; default: `"8080"`) - 
-Defines the port on which the daemon listens to.
 
 * **hdwallet_index** (optional; default: `0`; only applies if `hdwallet_mnemonic` is set) - 
 derivation index for key to use within HDWallet specified by mnemonic.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
-* **daemon_end_point** (mandatory; default: `"0.0.0.0:8080"`) - 
+* **daemon_end_point** (required;) - 
 Defines the ip and the port on which the daemon listens to.
 format is :`<host>:<port>`.
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,6 @@ configuration properties can be set using configuration file.
 These properties you should usually change before starting daemon for the first
 time.
 
-* **daemon_group_name** (required ,default: `"default_group"`) - 
-This parameter defines the group the daemon belongs to .
-The group helps determine the recipient address for payments.
-[service configuration
-metadata][service-configuration-metadata]. 
 
 * **ethereum_json_rpc_endpoint** (optional, default: `"http://127.0.0.1:8545"`) -
 endpoint to which daemon sends ethereum JSON-RPC requests; recommend
@@ -189,6 +184,12 @@ enables or disables blockchain features of daemon; `false` reserved mostly for t
 
 * **burst_size** (optional; default: Infinite) - 
 see [rate limiting configuration](./ratelimit/README.md)
+
+* **daemon_group_name** (optional ,default: `"default_group"`) - 
+This parameter defines the group the daemon belongs to .
+The group helps determine the recipient address for payments.
+[service configuration
+metadata][service-configuration-metadata]. 
 
 * **daemon_listening_port** (optional; default: `"8080"`) - 
 Defines the port on which the daemon listens to.

--- a/blockchain/serviceMetadata.go
+++ b/blockchain/serviceMetadata.go
@@ -119,11 +119,7 @@ func InitServiceMetaDataFromJson(jsonData string) (*ServiceMetadata, error) {
 }
 
 func setDerivedFields(metaData *ServiceMetadata) error {
-	err := setDaemonEndPoint(metaData)
-	if err != nil {
-		return err
-	}
-	err = setDaemonGroupName(metaData)
+	err := setDaemonGroupName(metaData)
 	if err != nil {
 		return err
 	}
@@ -141,24 +137,17 @@ func setMultiPartyEscrowAddress(metaData *ServiceMetadata) {
 
 }
 
-func setDaemonEndPoint(metaData *ServiceMetadata) error {
-	metaData.daemonEndPoint = config.GetString(config.DaemonEndPoint)
-	if len(metaData.daemonEndPoint) == 0 {
-		log.WithField("daemonEndPoint", metaData.daemonEndPoint)
-		return fmt.Errorf("check the Daemon End Point in the config")
-	}
-	return nil
-}
 
 func setDaemonGroupName(metaData *ServiceMetadata) error {
+	metaData.daemonGroupName = config.GetString(config.DaemonGroupName)
+	//Make sure the group name specified is in the config matches to some group name in metadata
 	for _, endpoints := range metaData.Endpoints {
-		if strings.Compare(metaData.daemonEndPoint, endpoints.Endpoint) == 0 {
-			metaData.daemonGroupName = endpoints.GroupName
+		if strings.Compare(metaData.daemonGroupName, endpoints.GroupName) == 0 {
 			return nil
 		}
 	}
-	log.WithField("DaemonEndPoint", metaData.daemonEndPoint)
-	return fmt.Errorf("unable to determine Daemon Group Name, DaemonEndPoint %s", metaData.daemonEndPoint)
+	log.WithField("daemon group name does not match any of the Group Names in Metadata", metaData.daemonGroupName)
+	return fmt.Errorf("please set the mandatory Daemon group Name corrrectly through the config %s ", config.DaemonGroupName)
 }
 
 func setDaemonGroupIDAndPaymentAddress(metaData *ServiceMetadata) error {

--- a/blockchain/serviceMetadata_test.go
+++ b/blockchain/serviceMetadata_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 )
 
-var daemonEndPoint string = config.GetString(config.DaemonEndPoint)
-var testJsonData = "{\"version\": 1, \"display_name\": \"Example1\", \"encoding\": \"grpc\", \"service_type\": \"grpc\", \"payment_expiration_threshold\": 40320, \"model_ipfs_hash\": \"QmQC9EoVdXRWmg8qm25Hkj4fG79YAgpNJCMDoCnknZ6VeJ\", \"mpe_address\": \"0x5C7a4290F6F8FF64c69eEffDFAFc8644A4Ec3a4E\", \"pricing\": {\"price_model\": \"fixed_price\", \"price_in_cogs\": 12000000}, \"groups\": [{\"group_name\": \"default_group\", \"group_id\": \"nXzNEetD1kzU3PZqR4nHPS8erDkrUK0hN4iCBQ4vH5U=\", \"payment_address\": \"0xD6C6344f1D122dC6f4C1782A4622B683b9008081\"}], \"endpoints\": [{\"group_name\": \"default_group\", \"endpoint\": \"" + daemonEndPoint + "\"}]}"
+var demonGroupName string = config.GetString(config.DaemonGroupName)
+var testJsonData = "{\"version\": 1, \"display_name\": \"Example1\", \"encoding\": \"grpc\", \"service_type\": \"grpc\", \"payment_expiration_threshold\": 40320, \"model_ipfs_hash\": \"QmQC9EoVdXRWmg8qm25Hkj4fG79YAgpNJCMDoCnknZ6VeJ\", \"mpe_address\": \"0x5C7a4290F6F8FF64c69eEffDFAFc8644A4Ec3a4E\", \"pricing\": {\"price_model\": \"fixed_price\", \"price_in_cogs\": 12000000}, \"groups\": [{\"group_name\": \"default_group\", \"group_id\": \"nXzNEetD1kzU3PZqR4nHPS8erDkrUK0hN4iCBQ4vH5U=\", \"payment_address\": \"0xD6C6344f1D122dC6f4C1782A4622B683b9008081\"}], \"endpoints\": [{\"group_name\": \"default_group\", \"endpoint\": \"\"}]}"
 
 func TestAllGetterMethods(t *testing.T) {
 	println(testJsonData)
@@ -21,7 +21,7 @@ func TestAllGetterMethods(t *testing.T) {
 	assert.Equal(t, metaData.GetDisplayName(), "Example1")
 	assert.Equal(t, metaData.GetServiceType(), "grpc")
 	assert.Equal(t, metaData.GetWireEncoding(), "grpc")
-	assert.Equal(t, metaData.GetDaemonEndPoint(), ""+daemonEndPoint)
+	assert.Equal(t, metaData.GetDaemonGroupName(),demonGroupName)
 	assert.Equal(t, metaData.GetPaymentAddress(), common.HexToAddress("0xD6C6344f1D122dC6f4C1782A4622B683b9008081"))
 	assert.Equal(t, metaData.GetPaymentExpirationThreshold(), big.NewInt(40320))
 	assert.Equal(t, metaData.GetPriceInCogs(), big.NewInt(12000000))
@@ -33,8 +33,9 @@ func TestAllGetterMethods(t *testing.T) {
 
 func TestServiceMetadata_GetDaemonGroupName(t *testing.T) {
 	//Change the Daemon end point in json to not match the daemon end point in config
-	_, err := InitServiceMetaDataFromJson(strings.Replace(testJsonData, ""+daemonEndPoint, "127.0.0.2:8080", -1))
-	assert.Equal(t, err.Error(), "unable to determine Daemon Group Name, DaemonEndPoint "+daemonEndPoint)
+	metadata, err := InitServiceMetaDataFromJson(testJsonData)
+	assert.Equal(t,metadata.daemonGroupName,"default_group")
+	assert.Equal(t,err,nil)
 
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,9 @@ const (
 	BurstSize            = "burst_size"
 	ConfigPathKey        = "config_path"
 
+	DaemonGroupName                = "daemon_group_name"
 	DaemonTypeKey                  = "daemon_type"
-	DaemonEndPoint                 = "daemon_end_point"
+	DaemonListeningPort            = "daemon_listening_port"
 	EthereumJsonRpcEndpointKey     = "ethereum_json_rpc_endpoint"
 	ExecutablePathKey              = "executable_path"
 	HdwalletIndexKey               = "hdwallet_index"
@@ -57,8 +58,9 @@ const (
 	"auto_ssl_domain": "",
 	"auto_ssl_cache_dir": ".certs",
 	"blockchain_enabled": true,
+	"daemon_group_name":"default_group",
+	"daemon_listening_port": 8080,
 	"daemon_type": "grpc",
-	"daemon_end_point": "127.0.0.1:8080",
 	"ethereum_json_rpc_endpoint": "http://127.0.0.1:8545",
 	"hdwallet_index": 0,
 	"hdwallet_mnemonic": "",

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ const (
 	"auto_ssl_domain": "",
 	"auto_ssl_cache_dir": ".certs",
 	"blockchain_enabled": true,
+	"daemon_end_point": "127.0.0.1:8080",
 	"daemon_group_name":"default_group",
 	"daemon_type": "grpc",
 	"ethereum_json_rpc_endpoint": "http://127.0.0.1:8545",

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ const (
 
 	DaemonGroupName                = "daemon_group_name"
 	DaemonTypeKey                  = "daemon_type"
-	DaemonListeningPort            = "daemon_listening_port"
+	DaemonEndPoint                 = "daemon_end_point"
 	EthereumJsonRpcEndpointKey     = "ethereum_json_rpc_endpoint"
 	ExecutablePathKey              = "executable_path"
 	HdwalletIndexKey               = "hdwallet_index"
@@ -59,7 +59,6 @@ const (
 	"auto_ssl_cache_dir": ".certs",
 	"blockchain_enabled": true,
 	"daemon_group_name":"default_group",
-	"daemon_listening_port": 8080,
 	"daemon_type": "grpc",
 	"ethereum_json_rpc_endpoint": "http://127.0.0.1:8545",
 	"hdwallet_index": 0,
@@ -168,7 +167,9 @@ func Validate() error {
 	if (certPath != "" && keyPath == "") || (certPath == "" && keyPath != "") {
 		return errors.New("SSL requires both key and certificate when enabled")
 	}
-
+	if !IsValidUrl(vip.GetString(DaemonEndPoint)) {
+		return errors.New("Daemon endpoint must be a valid of the form host:port")
+	}
 	// validate monitoring service endpoints
 	if vip.GetBool(MonitoringEnabled) &&
 		vip.GetString(MonitoringServiceEndpoint) != "" &&

--- a/config/config.go
+++ b/config/config.go
@@ -167,9 +167,6 @@ func Validate() error {
 	if (certPath != "" && keyPath == "") || (certPath == "" && keyPath != "") {
 		return errors.New("SSL requires both key and certificate when enabled")
 	}
-	if !IsValidUrl(vip.GetString(DaemonEndPoint)) {
-		return errors.New("Daemon endpoint must be a valid of the form host:port")
-	}
 	// validate monitoring service endpoints
 	if vip.GetBool(MonitoringEnabled) &&
 		vip.GetString(MonitoringServiceEndpoint) != "" &&

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -47,7 +47,7 @@ func TestHeartbeatHandler(t *testing.T) {
 	assert.Equal(t, dHeartbeat.Status, Online.String(), "Invalid State")
 	assert.NotEqual(t, dHeartbeat.Status, Offline.String(), "Invalid State")
 
-	assert.Equal(t, dHeartbeat.DaemonID, "10990b62daf504a0ae6094d548f25aed4928b1e991a9221a31693890c20d6916",
+	assert.Equal(t, dHeartbeat.DaemonID, "2188ffe79222a44083c315dbb6bc82f3292fa76131b226a85c8ed11361a2406f",
 		"Incorrect daemon ID")
 
 	assert.NotEqual(t, dHeartbeat.ServiceHeartbeat, `{}`, "Service Heartbeat must not be empty.")
@@ -66,7 +66,7 @@ func Test_GetHeartbeat(t *testing.T) {
 	assert.Equal(t, dHeartbeat.Status, Online.String(), "Invalid State")
 	assert.NotEqual(t, dHeartbeat.Status, Offline.String(), "Invalid State")
 
-	assert.Equal(t, dHeartbeat.DaemonID, "10990b62daf504a0ae6094d548f25aed4928b1e991a9221a31693890c20d6916",
+	assert.Equal(t, dHeartbeat.DaemonID, "2188ffe79222a44083c315dbb6bc82f3292fa76131b226a85c8ed11361a2406f",
 		"Incorrect daemon ID")
 
 	assert.NotEqual(t, dHeartbeat.ServiceHeartbeat, `{}`, "Service Heartbeat must not be empty.")

--- a/metrics/register.go
+++ b/metrics/register.go
@@ -20,7 +20,7 @@ Post beta, this ID will be used to enable Token based authentication for accessi
 
 // generates DaemonID nad returns i.e. DaemonID = HASH (Org Name, Service Name, daemon endpoint)
 func GetDaemonID() string {
-	rawID := config.GetString(config.OrganizationId) + config.GetString(config.ServiceId) + daemonGroupId + config.GetString(config.DaemonEndPoint) + config.GetString(config.RegistryAddressKey)
+	rawID := config.GetString(config.OrganizationId) + config.GetString(config.ServiceId) + daemonGroupId  + config.GetString(config.RegistryAddressKey)
 	//get hash of the string id combination
 	hasher := sha256.New()
 	hasher.Write([]byte(rawID))

--- a/metrics/register_test.go
+++ b/metrics/register_test.go
@@ -16,7 +16,7 @@ func TestGetDaemonID(t *testing.T) {
 
 	assert.NotNil(t, daemonID, "daemon ID must not be nil")
 	assert.NotEmpty(t, daemonID, "daemon ID must not be empty")
-	assert.Equal(t, "10990b62daf504a0ae6094d548f25aed4928b1e991a9221a31693890c20d6916", daemonID)
+	assert.Equal(t, "2188ffe79222a44083c315dbb6bc82f3292fa76131b226a85c8ed11361a2406f", daemonID)
 	assert.NotEqual(t, "48d343313a1e06093c81830103b45496cc7c277f321049e9ee632fd03207d042", daemonID)
 }
 

--- a/metrics/request_stats_test.go
+++ b/metrics/request_stats_test.go
@@ -20,7 +20,6 @@ func TestCreateRequestStat(t *testing.T) {
 	request := createRequestStat(commonStat)
 	assert.Equal(t, request.RequestID, commonStat.ID)
 	assert.Equal(t, request.GroupID, daemonGroupId)
-	assert.Equal(t, request.DaemonEndPoint, config.GetString(config.DaemonEndPoint))
 	assert.Equal(t, request.OrganizationID, config.GetString(config.OrganizationId))
 	assert.Equal(t, request.ServiceID, config.GetString(config.ServiceId))
 	assert.Equal(t, request.RequestReceivedTime, arrivalTime.String())

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -40,7 +40,6 @@ type ResponseStats struct {
 	OrganizationID             string `json:"organization_id"`
 	ServiceID                  string `json:"service_id"`
 	GroupID                    string `json:"group_id"`
-	DaemonEndPoint             string `json:"daemon_end_point"`
 	ServiceMethod              string `json:"service_method"`
 	ResponseSentTime           string `json:"response_sent_time"`
 	RequestReceivedTime        string `json:"request_received_time"`
@@ -64,7 +63,6 @@ func createResponseStats(commonStat *CommonStats, duration time.Duration, err er
 		RequestID:                  commonStat.ID,
 		ResponseTime:               strconv.FormatFloat(duration.Seconds(), 'f', 4, 64),
 		GroupID:                    daemonGroupId,
-		DaemonEndPoint:             commonStat.DaemonEndPoint,
 		OrganizationID:             commonStat.OrganizationID,
 		ServiceID:                  commonStat.ServiceID,
 		ServiceMethod:              commonStat.ServiceMethod,

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -23,7 +23,6 @@ func BuildCommonStats(receivedTime time.Time, methodName string) *CommonStats {
 		ID:                  GenXid(),
 		GroupID:             daemonGroupId,
 		RequestReceivedTime: receivedTime.String(),
-		DaemonEndPoint:      config.GetString(config.DaemonEndPoint),
 		OrganizationID:      config.GetString(config.OrganizationId),
 		ServiceID:           config.GetString(config.ServiceId),
 		ServiceMethod:       methodName,

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -100,7 +100,7 @@ func newDaemon(components *Components) (daemon, error) {
 	var err error
 	d.lis, err = net.Listen("tcp", config.GetString(config.DaemonEndPoint))
 	if err != nil {
-		return d, errors.Wrap(err, "error binding to the endpoint:"+config.GetString(config.DaemonEndPoint))
+		return d, errors.Wrap(err, "Expected format of daemon_end_point is <host>:<port>.Error binding to the endpoint:"+config.GetString(config.DaemonEndPoint))
 	}
 
 	d.autoSSLDomain = config.GetString(config.AutoSSLDomainKey)

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -98,10 +98,9 @@ func newDaemon(components *Components) (daemon, error) {
 	d.components = components
 
 	var err error
-	// The network must be "tcp", "tcp4", "tcp6", "unix" or "unixpacket".
 	d.lis, err = net.Listen("tcp", config.GetString(config.DaemonEndPoint))
 	if err != nil {
-		return d, errors.Wrap(err, "error listening")
+		return d, errors.Wrap(err, "error binding to the endpoint:"+config.GetString(config.DaemonEndPoint))
 	}
 
 	d.autoSSLDomain = config.GetString(config.AutoSSLDomainKey)

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -98,13 +98,8 @@ func newDaemon(components *Components) (daemon, error) {
 	d.components = components
 
 	var err error
-	port := config.GetString(config.DaemonListeningPort)
-	if err != nil {
-		return d, errors.Wrap(err, "error determining port")
-	}
-	log.WithField("port", port).Info("Starting listening port")
-
-	d.lis, err = net.Listen("tcp", fmt.Sprintf("0.0.0.0:%+v", port))
+	// The network must be "tcp", "tcp4", "tcp6", "unix" or "unixpacket".
+	d.lis, err = net.Listen("tcp", config.GetString(config.DaemonEndPoint))
 	if err != nil {
 		return d, errors.Wrap(err, "error listening")
 	}

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -99,7 +98,7 @@ func newDaemon(components *Components) (daemon, error) {
 	d.components = components
 
 	var err error
-	port, err := deriveDaemonPort(config.GetString(config.DaemonEndPoint))
+	port := config.GetString(config.DaemonListeningPort)
 	if err != nil {
 		return d, errors.Wrap(err, "error determining port")
 	}
@@ -133,29 +132,6 @@ func newDaemon(components *Components) (daemon, error) {
 	return d, nil
 }
 
-func deriveDaemonPort(daemonEndpoint string) (string, error) {
-	port := "8080"
-	var err error = nil
-
-	//There is a separate issue raised on standardizing the daemon end point format, #153, Daemon end point can also
-	//be entered in the format localhost:8080 or 127.1.0.0:8080 ( as this is allowed while defining the service metadata )
-	//For now strip http: or https: from the daemonEndPoint
-	daemonEndpoint = strings.Replace(daemonEndpoint, "https://", "", -1)
-	daemonEndpoint = strings.Replace(daemonEndpoint, "http://", "", -1)
-	splitString := strings.Split(daemonEndpoint, ":")
-	length := len(splitString)
-	if length == 2 {
-		port = splitString[len(splitString)-1]
-		_, err = strconv.ParseInt(port, 0, 16)
-		if err != nil {
-			log.WithField("daemonEndPoint", daemonEndpoint).Error(err)
-			err = fmt.Errorf("port number <%s> is not valid ,the daemon End point  %s", port, daemonEndpoint)
-		}
-	} else if length > 2 {
-		err = fmt.Errorf("daemon end point should have a single ':' ,the daemon End point %s", daemonEndpoint)
-	}
-	return port, err
-}
 
 func (d daemon) start() {
 

--- a/snetd/cmd/serve_test.go
+++ b/snetd/cmd/serve_test.go
@@ -1,40 +1,11 @@
 package cmd
 
 import (
-	"github.com/magiconair/properties/assert"
+	"github.com/singnet/snet-daemon/config"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func TestDeriveDaemonPort(t *testing.T) {
-	port1, err := deriveDaemonPort("127.0.0.1:8111")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "8111", port1)
-
-	port1, err = deriveDaemonPort("http://127.0.0.1:8111")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "8111", port1)
-
-	port1, err = deriveDaemonPort("https://127.0.0.1:8111")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "8111", port1)
-
-	port1, err = deriveDaemonPort("abcdefjl:wewee")
-	assert.Equal(t, "port number <wewee> is not valid ,the daemon End point  abcdefjl:wewee", err.Error())
-
-	port1, err = deriveDaemonPort("localhost:80:500")
-	assert.Equal(t, "daemon end point should have a single ':' ,the daemon End point localhost:80:500", err.Error())
-
-	port1, err = deriveDaemonPort("http://localhost:80:500")
-	assert.Equal(t, "daemon end point should have a single ':' ,the daemon End point localhost:80:500", err.Error())
-
-	port1, err = deriveDaemonPort("")
-	assert.Equal(t, port1, "8080")
-	assert.Equal(t, nil, err)
-
-	port1, err = deriveDaemonPort("127.0.0.1:")
-	assert.Equal(t, "port number <> is not valid ,the daemon End point  127.0.0.1:", err.Error())
-
-	port1, err = deriveDaemonPort("127.0.0.1")
-	assert.Equal(t, port1, "8080")
-	assert.Equal(t, nil, err)
+func TestDaemonPort(t *testing.T) {
+assert.Equal(t,config.GetString(config.DaemonListeningPort),"8080")
 }

--- a/snetd/cmd/serve_test.go
+++ b/snetd/cmd/serve_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
-
+//todo
 func TestDaemonPort(t *testing.T) {
-assert.Equal(t,config.GetString(config.DaemonEndPoint),"")
+assert.Equal(t,config.GetString(config.DaemonEndPoint),"127.0.0.1:8080")
 }

--- a/snetd/cmd/serve_test.go
+++ b/snetd/cmd/serve_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDaemonPort(t *testing.T) {
-assert.Equal(t,config.GetString(config.DaemonListeningPort),"8080")
+assert.Equal(t,config.GetString(config.DaemonEndPoint),"")
 }


### PR DESCRIPTION
Issue #199 

Get away from the Daemon End Point
Introduce group name to help with payments
Define the port number that the Daemon should listen to .

The issue with having a daemon end point was that it was forcing the endpoint defined to be exactly the same as what has been defined in the metadata ( this may not always be true as the daemon could run in a private network behind the NAT)
What has been defined in the meta data is for public access, how daemon runs in its private network or container should be agnostic to this public end point
