### PR TITLE
#issue 206, Better error handling 

### DIFF
--- a/blockchain/serviceMetadata.go
+++ b/blockchain/serviceMetadata.go
@@ -93,7 +93,7 @@ func getMetaDataUrifromRegistry() []byte {
 	serviceId := StringToBytes32(config.GetString(config.ServiceId))
 
 	serviceRegistration, err := reg.GetServiceRegistrationById(nil, orgId, serviceId)
-	if err != nil {
+	if err != nil || !serviceRegistration.Found {
 		log.WithError(err).WithField("OrganizationId", config.GetString(config.OrganizationId)).
 			WithField("ServiceId", config.GetString(config.ServiceId)).
 			Panic("Error Retrieving contract details for the Given Organization and Service Ids ")


### PR DESCRIPTION
If the Given OrganizationID and Service ID are not found in block chain, return back the error quoting this reason
#206 