### PR TITLE
Add nanoseconds to the timestamp

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,7 +79,8 @@ const (
 		"level": "info",
 		"timezone": "UTC",
 		"formatter": {
-			"type": "text"
+			"type": "text",
+			"timestamp_format": "2006-01-02T15:04:05.999999999Z07:00"
 		},
 		"output": {
 			"type": "file",

--- a/logger/README.md
+++ b/logger/README.md
@@ -29,6 +29,10 @@ configuration is one JSON object located in ```log``` field.
       * json
       * text
 
+    * **timestamp_format** (default:  "2006-01-02T15:04:05.999999999Z07:00") -
+      timestamp format to use in log lines, standard time.Time formats are
+      supported, see [time.Time.Format](https://golang.org/pkg/time/#Time.Format)
+
   * **output** - set of properties with ```log.output.``` prefix describes
     logger output configuration.
 
@@ -112,11 +116,12 @@ Resulting log configuration using logrus_mail hook:
 
 ```json
   "log": {
-    "level": "info",
-    "timezone": "UTC",
     "formatter": {
-      "type": "json"
+      "timestamp_format": "2006-01-02T15:04:05.999999999Z07:00",
+      "type": "text"
     },
+    "hooks": [],
+    "level": "info",
     "output": {
       "current_link": "./snet-daemon.log",
       "file_pattern": "./snet-daemon.%Y%m%d.log",
@@ -125,7 +130,7 @@ Resulting log configuration using logrus_mail hook:
       "rotation_time_in_sec": 86400,
       "type": "file"
     },
-    "hooks": []
+    "timezone": "UTC"
   }
 ```
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,8 +18,9 @@ const (
 	LogOutputKey    = "output"
 	LogHooksKey     = "hooks"
 
-	LogFormatterTypeKey     = "type"
-	LogFormatterTimezoneKey = "timezone"
+	LogFormatterTypeKey         = "type"
+	LogFormatterTimezoneKey     = "timezone"
+	LogFormatterTimestampFormat = "timestamp_format"
 
 	LogOutputTypeKey                  = "type"
 	LogOutputFileFilePatternKey       = "file_pattern"
@@ -88,11 +89,13 @@ func newFormatterByConfig(config *viper.Viper) (*timezoneFormatter, error) {
 	var err error
 	var formatter = &timezoneFormatter{}
 
+	var timestampFormat = config.GetString(LogFormatterTimestampFormat)
+
 	switch formatterType := config.GetString(LogFormatterTypeKey); formatterType {
 	case "text":
-		formatter.delegate = &log.TextFormatter{}
+		formatter.delegate = &log.TextFormatter{FullTimestamp: true, TimestampFormat: timestampFormat}
 	case "json":
-		formatter.delegate = &log.JSONFormatter{}
+		formatter.delegate = &log.JSONFormatter{TimestampFormat: timestampFormat}
 	default:
 		return nil, fmt.Errorf("Unexpected formatter type: %v", formatterType)
 	}


### PR DESCRIPTION
Add new field timestamp_format into logger configuration to allow showing nanoseconds in timestamps.
Add nanoseconds by default.