### PR TITLE
Simplify gRPC interceptor logic

### DIFF
--- a/escrow/escrow.go
+++ b/escrow/escrow.go
@@ -35,7 +35,7 @@ func NewPaymentChannelService(
 	}
 }
 
-func (h *lockingPaymentChannelService)  PaymentChannelFromBlockChain (key *PaymentChannelKey) (channel *PaymentChannelData, ok bool, err error) {
+func (h *lockingPaymentChannelService) PaymentChannelFromBlockChain(key *PaymentChannelKey) (channel *PaymentChannelData, ok bool, err error) {
 	return h.blockchainReader.GetChannelStateFromBlockchain(key)
 }
 
@@ -208,8 +208,11 @@ func (payment *paymentTransaction) Commit() error {
 		err := payment.lock.Unlock()
 		if err != nil {
 			log.WithError(err).WithField("payment", payment).Error("Channel cannot be unlocked because of error. All other transactions on this channel will be blocked until unlock. Please unlock channel manually.")
+		} else {
+			log.Debug("Channel unlocked")
 		}
 	}(payment)
+
 	e := payment.service.storage.Put(
 		&PaymentChannelKey{ID: payment.payment.ChannelID},
 		&PaymentChannelData{
@@ -231,6 +234,7 @@ func (payment *paymentTransaction) Commit() error {
 		return NewPaymentError(Internal, "unable to store new payment channel state")
 	}
 
+	log.Debug("Payment completed")
 	return nil
 }
 
@@ -239,6 +243,8 @@ func (payment *paymentTransaction) Rollback() error {
 		err := payment.lock.Unlock()
 		if err != nil {
 			log.WithError(err).WithField("payment", payment).Error("Channel cannot be unlocked because of error. All other transactions on this channel will be blocked until unlock. Please unlock channel manually.")
+		} else {
+			log.Debug("Payment rolled back, channel unlocked")
 		}
 	}(payment)
 	return nil

--- a/handler/interceptors.go
+++ b/handler/interceptors.go
@@ -192,19 +192,22 @@ func (interceptor *paymentValidationInterceptor) intercept(srv interface{}, ss g
 		return err.Err()
 	}
 
-	handlerSucceed := false
-
 	defer func() {
-		if !handlerSucceed {
-			if r := recover(); r != nil {
-				log.WithField("panicValue", r).Warn("Service handler called panic(panicValue)")
-				paymentHandler.CompleteAfterError(payment, fmt.Errorf("Service handler called panic(%v)", r))
-				panic("re-panic after payment handler error handling")
-			} else if e != nil {
-				err = paymentHandler.CompleteAfterError(payment, e)
-				if err != nil {
-					e = err.Err()
-				}
+		if r := recover(); r != nil {
+			log.WithField("panicValue", r).Warn("Service handler called panic(panicValue)")
+			paymentHandler.CompleteAfterError(payment, fmt.Errorf("Service handler called panic(%v)", r))
+			panic("re-panic after payment handler error handling")
+		} else if e == nil {
+			err = paymentHandler.Complete(payment)
+			if err != nil {
+				// return err.Err()
+				e = err.Err()
+			}
+		} else {
+			err = paymentHandler.CompleteAfterError(payment, e)
+			if err != nil {
+				// return err.Err()
+				e = err.Err()
 			}
 		}
 	}()
@@ -212,19 +215,10 @@ func (interceptor *paymentValidationInterceptor) intercept(srv interface{}, ss g
 	log.WithField("payment", payment).Debug("New payment received")
 
 	e = handler(srv, ss)
-
 	if e != nil {
 		log.WithError(e).Warn("gRPC handler returned error")
 		return e
 	}
-
-	handlerSucceed = true
-
-	err = paymentHandler.Complete(payment)
-	if err != nil {
-		return err.Err()
-	}
-	log.Debug("Payment completed")
 
 	return nil
 }

--- a/handler/interceptors_test.go
+++ b/handler/interceptors_test.go
@@ -106,7 +106,7 @@ func (suite *InterceptorsSuite) SetupTest() {
 	suite.paymentHandler.reset()
 }
 
-func TestIntersecptorsSuite(t *testing.T) {
+func TestInterceptorsSuite(t *testing.T) {
 	suite.Run(t, new(InterceptorsSuite))
 }
 


### PR DESCRIPTION
Move Complete() call to the deferred block to have all payment completion logic in same place.
Add logs to payment handler to clearly designate payment completion state and channel state in logs.
Add unit test to test Complete() call.