### PR TITLE
Support cross compilation with xgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ go get -u google.golang.org/grpc
 $ sudo apt-get install golint
 ```
 
+* If you want to cross-compile you will also need Docker
+
 ### Installing
 
 * Clone the git repository to the following path $GOPATH/src/github.com/singnet/
@@ -57,7 +59,7 @@ $ cd snet-daemon
 $ ./scripts/install
 ```
 
-* Build snet-daemon (on Linux amd64 platform)
+* Build snet-daemon (on Linux amd64 platform), see below section if you want to cross compile instead.
 ```bash
 $ ./scripts/build linux amd64
 ```
@@ -68,12 +70,16 @@ $ ./build/snetd-linux-amd64 init
 ```
 **** Please update the registry address in daemon config based on the test network used 
 
+#### Cross-compiling
+
+If you want to build snetd for platforms other than the one you are on, run `./scripts/build-xgo` instead of `./scripts/build`.
+
+You can edit the script to choose a specific platform, but by default it will build for Linux, OSX, and Windows (amd64 for all, except Linux which will also build for arm6)
+
 #### Run Deamon
 ```bash
 $ ../build/snetd-linux-amd64
 ```
-
-
 
 
 ### Main commands

--- a/ratelimit/rateLimit.go
+++ b/ratelimit/rateLimit.go
@@ -12,7 +12,7 @@ func NewRateLimiter() rate.Limiter {
 	//By Default set the maximum value possible for the Burst Size ( assuming rate was defined ,but burst was not defined)
 	burstSize := config.GetInt(config.BurstSize)
 	if burstSize == 0 {
-		burstSize = math.MaxInt64
+		burstSize = math.MaxInt32
 	}
 	limiter := rate.NewLimiter(getLimit(), burstSize)
 	return *limiter

--- a/scripts/build-xgo
+++ b/scripts/build-xgo
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -ex
+
+PARENT_PATH=$(dirname $(cd $(dirname $0); pwd -P))
+pushd $PARENT_PATH
+
+# Make sure we have xgo
+go get -u github.com/karalabe/xgo
+
+# Apply patch for OSX, Go 1.10 and old notify version
+# https://stackoverflow.com/questions/54064293/cannot-use-nil-as-type-ctype-cfallocatorref-in-argument-to-func-literal
+# Can be removed if we upgrade notify (which probably requires upgrading go-ethereum etc.)
+pushd vendor/github.com/rjeczalik/notify
+patch -N < $PARENT_PATH/scripts/watcher_fsevents_cgo.go.patch || true
+popd
+
+mkdir -p build
+
+# Stuck on Go 1.10.x until https://github.com/singnet/snet-daemon/issues/201 is resolved.
+GO_VERSION=1.10.x
+
+# All targets compiled when Joel tried (2019-March), but we probably don't want to build them all!
+#TARGETS=*/*
+
+# See here for details
+# https://github.com/karalabe/xgo#limit-build-targets
+TARGETS=linux/amd64,linux/arm-6,darwin-10.6/amd64,windows/amd64
+xgo -dest build -go $GO_VERSION -targets=$TARGETS ./snetd

--- a/scripts/watcher_fsevents_cgo.go.patch
+++ b/scripts/watcher_fsevents_cgo.go.patch
@@ -1,0 +1,22 @@
+--- /home/joel/Downloads/watcher_fsevents_cgo.go	2019-03-20 13:14:12.643748593 +1300
++++ watcher_fsevents_cgo.go	2019-03-20 12:49:33.489170174 +1300
+@@ -48,7 +48,7 @@
+ // started and is ready via the wg. It also serves purpose of a dummy source,
+ // thanks to it the runloop does not return as it also has at least one source
+ // registered.
+-var source = C.CFRunLoopSourceCreate(nil, 0, &C.CFRunLoopSourceContext{
++var source = C.CFRunLoopSourceCreate(C.kCFAllocatorDefault, 0, &C.CFRunLoopSourceContext{
+ 	perform: (C.CFRunLoopPerformCallBack)(C.gosource),
+ })
+ 
+@@ -162,8 +162,8 @@
+ 		return nil
+ 	}
+ 	wg.Wait()
+-	p := C.CFStringCreateWithCStringNoCopy(nil, C.CString(s.path), C.kCFStringEncodingUTF8, nil)
+-	path := C.CFArrayCreate(nil, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
++	p := C.CFStringCreateWithCStringNoCopy(C.kCFAllocatorDefault, C.CString(s.path), C.kCFStringEncodingUTF8, C.kCFAllocatorDefault)
++	path := C.CFArrayCreate(C.kCFAllocatorDefault, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
+ 	ctx := C.FSEventStreamContext{}
+ 	ref := C.EventStreamCreate(&ctx, C.uintptr_t(s.info), path, C.FSEventStreamEventId(atomic.LoadUint64(&since)), latency, flags)
+ 	if ref == nilstream {

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/singnet/snet-daemon/metrics"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -172,7 +173,7 @@ func (d daemon) start() {
 
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
 		// set the maximum that the server can receive to 4GB. It is set to for 4GB because of issue here https://github.com/grpc/grpc-go/issues/1590
-		maxsizeOpt := grpc.MaxRecvMsgSize(4000000000)
+		maxsizeOpt := grpc.MaxRecvMsgSize(math.MaxInt32)
 		d.grpcServer = grpc.NewServer(
 			grpc.UnknownServiceHandler(handler.NewGrpcHandler(d.components.ServiceMetaData())),
 			grpc.StreamInterceptor(d.components.GrpcInterceptor()),


### PR DESCRIPTION
I've added a script using xgo, to allow us to build for arm6 (raspberry pi). Fixes #227

Side benefit of this is approach is that I was able to build for almost every platform Go supports (so also fixes #215).

However, I've constrained the default behaviour to only build for the major platforms.

Also changes some Int64 constants to fit in Int32 so compilation on arm works.