### PR TITLE
Add config check to validate daemon and passthrough endpoints

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,3 +104,14 @@ func TestValidateEmail(t *testing.T) {
 	valid = ValidateEmail("abc@xyz")
 	assert.Equal(t, false, valid)
 }
+
+func TestValidateEndpoints(t *testing.T) {
+	err := ValidateEndpoints("0.0.0.0:8080", "http://127.0.0.1:8080")
+	assert.NotEqual(t, nil, err)
+	err = ValidateEndpoints("127.0.0.1:8080", "http://127.0.0.1:8080")
+	assert.NotEqual(t, nil, err)
+	err = ValidateEndpoints("0.0.0.0:8080", "http://127.0.0.1:5000")
+	assert.Equal(t, nil, err)
+	err = ValidateEndpoints("1.2.3.4:8080", "http://127.0.0.1:8080")
+	assert.Equal(t, nil, err)
+}


### PR DESCRIPTION
Mainly to check they are not the same and fix #217

Doesn't catch any ipv6 stuff, or whether a domain resolves to the same IP, but should catch the bad config I was using that had the daemon calling itself, and that confused me for a couple of days! :sweat_smile: 