### PR TITLE
Issue : 195 -  make the max message size a config key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ metadata][service-configuration-metadata].
 * **log** (optional) - 
 see [logger configuration](./logger/README.md)
 
-* **max_message_size_in_mb** (optional; default: `4MB`) - 
-The default value set is to 4 MB, this is used to configure the max size in MB of the message received by the Daemon.
+* **max_message_size_in_mb** (optional; default: `4`) - 
+The default value set is to 4 (units are in MB ), this is used to configure the max size in MB of the message received by the Daemon.
 In case of Large messages , it is recommended to use streaming than setting a very high value on this configuration.
 It is not recommended to set the value more than 4GB
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ metadata][service-configuration-metadata].
 * **log** (optional) - 
 see [logger configuration](./logger/README.md)
 
+* **max_message_size_in_mb** (optional; default: `4MB`) - 
+The default value set is to 4 MB, this is used to configure the max size in MB of the message received by the Daemon.
+In case of Large messages , it is recommended to use streaming than setting a very high value on this configuration.
+It is not recommended to set the value more than 4GB
+
 * **monitoring_enabled** (optional; default: `true`) - 
 Enable or Disable monitoring of Requests arrived and response sent back
 

--- a/config/config.go
+++ b/config/config.go
@@ -188,8 +188,8 @@ func Validate() error {
 	// the maximum that the server can receive to 4GB.
 	// 4GB because of issue here https://github.com/grpc/grpc-go/issues/1590
 	maxMessageSize:= vip.GetInt(MaxMessageSizeInMB)
-	if ( maxMessageSize <=0 || maxMessageSize > 4096)   {
-		return errors.New(" max_message_size_in_mb cannot be more than 4GB (i.e 4096 MB) and has to be a positive number")
+	if ( maxMessageSize <=0 || maxMessageSize > 2048)   {
+		return errors.New(" max_message_size_in_mb cannot be more than 2GB (i.e 2048 MB) and has to be a positive number")
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -185,8 +185,7 @@ func Validate() error {
 		return err
 	}
 
-	// the maximum that the server can receive to 4GB.
-	// 4GB because of issue here https://github.com/grpc/grpc-go/issues/1590
+	// the maximum that the server can receive to 2GB.
 	maxMessageSize:= vip.GetInt(MaxMessageSizeInMB)
 	if ( maxMessageSize <=0 || maxMessageSize > 2048)   {
 		return errors.New(" max_message_size_in_mb cannot be more than 2GB (i.e 2048 MB) and has to be a positive number")

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ const (
 	IpfsEndPoint                   = "ipfs_end_point"
 	IpfsTimeout                    = "ipfs_timeout"
 	LogKey                         = "log"
+	MaxMessageSizeInMB             = "max_message_size_in_mb"
 	MonitoringEnabled              = "monitoring_enabled"
 	MonitoringServiceEndpoint      = "monitoring_svc_end_point"
 	OrganizationId                 = "organization_id"
@@ -64,6 +65,7 @@ const (
 	"hdwallet_mnemonic": "",
 	"ipfs_end_point": "http://localhost:5002/", 
 	"ipfs_timeout" : 30,
+	"max_message_size_in_mb" : 4,
 	"monitoring_enabled": true,
 	"monitoring_svc_end_point": "https://n4rzw9pu76.execute-api.us-east-1.amazonaws.com/beta",
 	"organization_id": "ExampleOrganizationId", 
@@ -173,6 +175,8 @@ func Validate() error {
 		!IsValidUrl(vip.GetString(MonitoringServiceEndpoint)) {
 		return errors.New("service endpoint must be a valid URL")
 	}
+
+	// Validate metrics URL and set state
 	passEndpoint := vip.GetString(PassthroughEndpointKey)
 	daemonEndpoint := vip.GetString(DaemonEndPoint)
 	var err error
@@ -181,7 +185,12 @@ func Validate() error {
 		return err
 	}
 
-	// Validate metrics URL and set state
+	// the maximum that the server can receive to 4GB.
+	// 4GB because of issue here https://github.com/grpc/grpc-go/issues/1590
+	maxMessageSize:= vip.GetInt(MaxMessageSizeInMB)
+	if ( maxMessageSize <=0 || maxMessageSize > 4096)   {
+		return errors.New(" max_message_size_in_mb cannot be more than 4GB (i.e 4096 MB) and has to be a positive number")
+	}
 	return nil
 }
 

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -173,7 +173,7 @@ func (d daemon) start() {
 
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
 
-		maxsizeOpt := grpc.MaxRecvMsgSize(config.GetInt(config.MaxMessageSizeInMB) * 1000000)
+		maxsizeOpt := grpc.MaxRecvMsgSize(config.GetInt(config.MaxMessageSizeInMB) * 1024 * 1024)
 		d.grpcServer = grpc.NewServer(
 			grpc.UnknownServiceHandler(handler.NewGrpcHandler(d.components.ServiceMetaData())),
 			grpc.StreamInterceptor(d.components.GrpcInterceptor()),

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/singnet/snet-daemon/metrics"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -173,8 +172,8 @@ func (d daemon) start() {
 	}
 
 	if config.GetString(config.DaemonTypeKey) == "grpc" {
-		// set the maximum that the server can receive to 4GB. It is set to for 4GB because of issue here https://github.com/grpc/grpc-go/issues/1590
-		maxsizeOpt := grpc.MaxRecvMsgSize(math.MaxInt32)
+
+		maxsizeOpt := grpc.MaxRecvMsgSize(config.GetInt(config.MaxMessageSizeInMB) * 1000000)
 		d.grpcServer = grpc.NewServer(
 			grpc.UnknownServiceHandler(handler.NewGrpcHandler(d.components.ServiceMetaData())),
 			grpc.StreamInterceptor(d.components.GrpcInterceptor()),


### PR DESCRIPTION
Default value has been set to 4MB 
Any attempt to set the value  beyond 4GB will fail with an error 
