### PR TITLE
to make authorization in state_service the same as in control_service(fix for issue#228)

### DIFF
--- a/authutils/auth_service.go
+++ b/authutils/auth_service.go
@@ -1,0 +1,102 @@
+//  authutils package provides functions for all authentication and singature validation related operations
+package authutils
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/singnet/snet-daemon/blockchain"
+	log "github.com/sirupsen/logrus"
+	"math/big"
+	"context"
+)
+
+// TODO convert to separate authentication service. VERY MUCH REQUIRED FOR OPERATOR UI AUTHENTICATION
+
+// Extracts the signer address from signature given the signature
+// It returns signer address and error. nil error indicates the successful function execution
+func GetSignerAddressFromMessage(message, signature []byte) (signer *common.Address, err error) {
+	log := log.WithFields(log.Fields{
+		"message":   blockchain.BytesToBase64(message),
+		"signature": blockchain.BytesToBase64(signature),
+	})
+
+	messageHash := crypto.Keccak256(
+		blockchain.HashPrefix32Bytes,
+		crypto.Keccak256(message),
+	)
+	log = log.WithField("messageHash", hex.EncodeToString(messageHash))
+
+	v, _, _, e := blockchain.ParseSignature(signature)
+	if e != nil {
+		log.WithError(e).Warn("Error parsing signature")
+		return nil, errors.New("incorrect signature length")
+	}
+
+	modifiedSignature := bytes.Join([][]byte{signature[0:64], {v % 27}}, nil)
+	publicKey, e := crypto.SigToPub(messageHash, modifiedSignature)
+	if e != nil {
+		log.WithError(e).WithField("modifiedSignature", modifiedSignature).Warn("Incorrect signature")
+		return nil, errors.New("incorrect signature data")
+	}
+	log = log.WithField("publicKey", publicKey)
+
+	keyOwnerAddress := crypto.PubkeyToAddress(*publicKey)
+	log.WithField("keyOwnerAddress", keyOwnerAddress).Debug("Message signature parsed")
+
+	return &keyOwnerAddress, nil
+}
+
+// Verify the signature done by given singer or not
+// returns nil if signer indeed sign the message and singature proves it, if not throws an error
+func VerifySigner(message []byte, signature []byte, signer common.Address) error {
+	signerFromMessage, err := GetSignerAddressFromMessage(message, signature)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if signerFromMessage.String() == signer.String(){
+		return nil
+	}
+	return fmt.Errorf("Incorrect signer.")
+}
+
+//Check if the block number passed is not more +- 5 from the latest block number on chain
+func CompareWithLatestBlockNumber(blockNumberPassed *big.Int) error {
+	latestBlockNumber, err := CurrentBlock()
+	if err != nil {
+		return err
+	}
+	differenceInBlockNumber := latestBlockNumber.Cmp(blockNumberPassed)
+	if -5 <= differenceInBlockNumber || differenceInBlockNumber <= 5 {
+		return nil
+	}
+	return fmt.Errorf("difference between the latest block chain number and the block number passed is %v ", blockNumberPassed)
+}
+
+//Get the current block number from on chain
+func CurrentBlock() (*big.Int, error) {
+	if ethClient, err := blockchain.GetEthereumClient(); err != nil {
+		return nil, err
+	} else {
+		defer ethClient.RawClient.Close()
+		var currentBlockHex string
+		if err = ethClient.RawClient.CallContext(context.Background(), &currentBlockHex, "eth_blockNumber"); err != nil {
+			log.WithError(err).Error("error determining current block")
+			return nil, fmt.Errorf("error determining current block: %v", err)
+		}
+		return new(big.Int).SetBytes(common.FromHex(currentBlockHex)), nil
+	}
+}
+
+//Check if the payment address/signer passed matches to what is present in the metadata
+func VerifyPaymentAddress(address common.Address, paymentAddress common.Address) (error) {
+	isSameAddress := paymentAddress == address
+	if !isSameAddress {
+		return fmt.Errorf("the payment Address: %s  does not match to what has been registered", blockchain.AddressToHex(&address))
+	}
+	return nil
+}

--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -46,6 +46,10 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		return nil, fmt.Errorf("channel is not found, channelId: %v", channelID)
 	}
 
+	if err := authutils.CompareWithLatestBlockNumber(big.NewInt(int64(request.CurrentBlock))); err != nil {
+		return nil, err
+	}
+
 	message := bytes.Join([][]byte{
 		[]byte ("__get_channel_state"),
 		channelID.Bytes(),

--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/singnet/snet-daemon/authutils"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"math/big"
 )
 
 // PaymentChannelStateService is an implementation of
@@ -45,15 +46,10 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		return nil, fmt.Errorf("channel is not found, channelId: %v", channelID)
 	}
 
-	currentBlock, err := authutils.CurrentBlock()
-	if err != nil {
-		return nil, errors.New("unable to read current block number")
-	}
-
 	message := bytes.Join([][]byte{
 		[]byte ("__get_channel_state"),
 		channelID.Bytes(),
-		abi.U256(currentBlock),
+		abi.U256(big.NewInt(int64(request.CurrentBlock))),
 	}, nil)
 	signature := request.GetSignature()
 

--- a/escrow/state_service.proto
+++ b/escrow/state_service.proto
@@ -24,9 +24,11 @@ service PaymentChannelStateService {
 message ChannelStateRequest {
     // channel_id contains id of the channel which state is requested.
     bytes channel_id = 1;
+    //current block number (signature will be valid only for short time around this block number)
+    uint64 current_block = 2;
     // signature is a client signature of the message which contains
     // channel_id. It is used for client authorization.
-    bytes signature = 2;
+    bytes signature = 3;
 }
 
 // ChannelStateReply message contains a latest channel state. current_nonce and

--- a/escrow/state_service_test.go
+++ b/escrow/state_service_test.go
@@ -52,7 +52,7 @@ var stateServiceTest = func() stateServiceTestType {
 		panic("Could not make default previous Signature")
 	}
 
-	//abi.U256(big.NewInt(int64(request.CurrentBlock))),
+	// read the current block number from blockchain,
 	defaultBlock, err := authutils.CurrentBlock()
 	if err != nil {
 		panic("Could not read current blocknumber")

--- a/escrow/state_service_test.go
+++ b/escrow/state_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/singnet/snet-daemon/authutils"
 	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
@@ -51,7 +52,12 @@ var stateServiceTest = func() stateServiceTestType {
 		panic("Could not make default previous Signature")
 	}
 
-	defaultBlock := big.NewInt(0)
+	//abi.U256(big.NewInt(int64(request.CurrentBlock))),
+	defaultBlock, err := authutils.CurrentBlock()
+	if err != nil {
+		panic("Could not read current blocknumber")
+	}
+
 	defaultChannelIdA := big.NewInt(43)
 	message := bytes.Join([][]byte{
 		[]byte ("__get_channel_state"),
@@ -83,6 +89,7 @@ var stateServiceTest = func() stateServiceTestType {
 		},
 		defaultRequest: &ChannelStateRequest{
 			ChannelId: bigIntToBytes(defaultChannelId),
+			CurrentBlock: defaultBlock.Uint64(),
 			Signature: getSignature(bigIntToBytes(defaultChannelId), signerPrivateKey),
 		},
 		defaultReply: &ChannelStateReply{
@@ -106,6 +113,7 @@ var stateServiceTest = func() stateServiceTestType {
 		},
 		defaultRequestA: &ChannelStateRequest{
 			ChannelId: bigIntToBytes(defaultChannelIdA),
+			CurrentBlock: defaultBlock.Uint64(),
 			Signature: newFormatSignature,
 		},
 		defaultReplyA: &ChannelStateReply{

--- a/escrow/validation.go
+++ b/escrow/validation.go
@@ -2,10 +2,8 @@ package escrow
 
 import (
 	"bytes"
-	"encoding/hex"
-	"errors"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/singnet/snet-daemon/authutils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"math/big"
@@ -76,7 +74,7 @@ func getSignerAddressFromPayment(payment *Payment) (signer *common.Address, err 
 		bigIntToBytes(payment.Amount),
 	}, nil)
 
-	signer, err = getSignerAddressFromMessage(message, payment.Signature)
+	signer, err = authutils.GetSignerAddressFromMessage(message, payment.Signature)
 	if err != nil {
 		log.WithField("payment", payment).WithError(err).Error("Cannot get signer from payment")
 		return nil, err
@@ -85,37 +83,6 @@ func getSignerAddressFromPayment(payment *Payment) (signer *common.Address, err 
 	return signer, err
 }
 
-func getSignerAddressFromMessage(message, signature []byte) (signer *common.Address, err error) {
-	log := log.WithFields(log.Fields{
-		"message":   blockchain.BytesToBase64(message),
-		"signature": blockchain.BytesToBase64(signature),
-	})
-
-	messageHash := crypto.Keccak256(
-		blockchain.HashPrefix32Bytes,
-		crypto.Keccak256(message),
-	)
-	log = log.WithField("messageHash", hex.EncodeToString(messageHash))
-
-	v, _, _, e := blockchain.ParseSignature(signature)
-	if e != nil {
-		log.WithError(e).Warn("Error parsing signature")
-		return nil, errors.New("incorrect signature length")
-	}
-
-	modifiedSignature := bytes.Join([][]byte{signature[0:64], {v % 27}}, nil)
-	publicKey, e := crypto.SigToPub(messageHash, modifiedSignature)
-	if e != nil {
-		log.WithError(e).WithField("modifiedSignature", modifiedSignature).Warn("Incorrect signature")
-		return nil, errors.New("incorrect signature data")
-	}
-	log = log.WithField("publicKey", publicKey)
-
-	keyOwnerAddress := crypto.PubkeyToAddress(*publicKey)
-	log.WithField("keyOwnerAddress", keyOwnerAddress).Debug("Message signature parsed")
-
-	return &keyOwnerAddress, nil
-}
 
 func bigIntToBytes(value *big.Int) []byte {
 	return common.BigToHash(value).Bytes()


### PR DESCRIPTION
this fix has 2 of the following changes
1. change the authorizaion logic in state service similar to the control service. as part of the message to be signed will contain the following fields now instead channel id before
- "__get_channel_state" text 
- channel ID
- current block number
we have added fall back to older message format as well, since it may break the interaction with CLI, if the developers are using older CLI versions. this backward compatibility can be removed in future releases.

2. moved some of the common authorization code to separate package, so that we can extend it to build the authentication service for upcoming changes like operator UI

added basic tests to verify the changes.  but we may have to review and add bit more detailed tests while developing it for operator UI

@vsbogd @astroseger can you please review the changes and let me know if incase of any changes/suggestion