### PR TITLE
https://github.com/singnet/snet-daemon/issues/209

### DIFF
--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -130,7 +130,7 @@ func newDaemon(components *Components) (daemon, error) {
 }
 
 
-func (d daemon) start() {
+func (d *daemon) start() {
 
 	var tlsConfig *tls.Config
 

--- a/snetd/cmd/serve.go
+++ b/snetd/cmd/serve.go
@@ -130,7 +130,7 @@ func newDaemon(components *Components) (daemon, error) {
 }
 
 
-func (d *daemon) start() {
+func (d daemon) start() {
 
 	var tlsConfig *tls.Config
 
@@ -221,7 +221,7 @@ func (d *daemon) start() {
 
 }
 
-func (d daemon) stop() {
+func (d *daemon) stop() {
 
 	if d.grpcServer != nil {
 		d.grpcServer.GracefulStop()


### PR DESCRIPTION
changes made inside a method with a pointer receiver is visible to the caller whereas this is not the case in value receiver
made start to have pointer receiver