### PR TITLE
#287, Add mpe_address to GetChannelState authentication

### DIFF
--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -69,8 +69,8 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 	// signature verification
 	message := bytes.Join([][]byte{
 		[]byte("__get_channel_state"),
-		bigIntToBytes(channelID),
 		service.mpeAddress().Bytes(),
+		bigIntToBytes(channelID),
 		abi.U256(big.NewInt(int64(request.CurrentBlock))),
 	}, nil)
 	signature := request.GetSignature()

--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/singnet/snet-daemon/authutils"
+	"github.com/singnet/snet-daemon/blockchain"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"math/big"
@@ -17,6 +19,7 @@ import (
 type PaymentChannelStateService struct {
 	channelService PaymentChannelService
 	paymentStorage *PaymentStorage
+	mpeAddress func() (address common.Address)
 }
 
 // verifies whether storage channel nonce is equal to blockchain nonce or not
@@ -35,10 +38,11 @@ func (service *PaymentChannelStateService) StorageNonceMatchesWithBlockchainNonc
 }
 
 // NewPaymentChannelStateService returns new instance of PaymentChannelStateService
-func NewPaymentChannelStateService(channelService PaymentChannelService, paymentStorage *PaymentStorage) *PaymentChannelStateService {
+func NewPaymentChannelStateService(channelService PaymentChannelService, paymentStorage *PaymentStorage,metaData *blockchain.ServiceMetadata) *PaymentChannelStateService {
 	return &PaymentChannelStateService{
 		channelService: channelService,
 		paymentStorage: paymentStorage,
+		mpeAddress:func() common.Address { return metaData.GetMpeAddress() },
 	}
 }
 
@@ -66,6 +70,7 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 	message := bytes.Join([][]byte{
 		[]byte("__get_channel_state"),
 		bigIntToBytes(channelID),
+		service.mpeAddress().Bytes(),
 		abi.U256(big.NewInt(int64(request.CurrentBlock))),
 	}, nil)
 	signature := request.GetSignature()

--- a/escrow/state_service_test.go
+++ b/escrow/state_service_test.go
@@ -53,11 +53,13 @@ var stateServiceTest = func() stateServiceTestType {
 	}
 
 	paymentStorage := NewPaymentStorage(NewMemStorage())
+	verificationAddress:= common.HexToAddress("0xf25186b5081ff5ce73482ad761db0eb0d25abfbf")
 
 	return stateServiceTestType{
 		service: PaymentChannelStateService{
 			channelService: channelServiceMock,
 			paymentStorage: paymentStorage,
+			mpeAddress: func() common.Address {return verificationAddress},
 		},
 		senderAddress:      senderAddress,
 		signerPrivateKey:   signerPrivateKey,

--- a/snetd/cmd/components.go
+++ b/snetd/cmd/components.go
@@ -251,7 +251,7 @@ func (components *Components) PaymentChannelStateService() (service *escrow.Paym
 	components.paymentChannelStateService = escrow.NewPaymentChannelStateService(
 		components.PaymentChannelService(),
 		components.PaymentStorage(),
-	)
+		components.ServiceMetaData())
 
 	return components.paymentChannelStateService
 }


### PR DESCRIPTION
add mpe_address to the message in GetChannelState authentication.

So the client should sign the following message: __get_channel_state , **mpe_address**, Channel ID, Current block