### PR TITLE
Single Channel ( Support for reading Organization - Group Level Metadata) 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9-node
+      - image: circleci/golang:1.10.4-node
     working_directory: /go/src/github.com/singnet/snet-daemon
     environment:
       TRIGGER_BUILD_BRANCH: master

--- a/blockchain/orginzationMetadata.go
+++ b/blockchain/orginzationMetadata.go
@@ -1,0 +1,176 @@
+package blockchain
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/singnet/snet-daemon/config"
+	"github.com/singnet/snet-daemon/ipfsutils"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+/*
+This metadata structure defines the organization to group mappings.
+Please note , that groups are logical bucketing of managing payments ( same recipient for each group across the services in an organization)
+A given Organization will be associated with multiple groups and every group will be associated to a payment
+Sample example of the JSON structure from the block chain is given below .
+Please note that all the services that belong to a given group in an organization will have the same recipient address.
+*/
+
+/*
+
+{
+"org_name": "organization_name",
+"org_id": "org_id1",
+"groups": [
+		{
+			"group_name": "group1",
+			"group_id": "99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=",
+			"payment_address": "0x671276c61943A35D5F230d076bDFd91B0c47bF09",
+			"payment_channel_storage_type": "etcd",
+			"payment_channel_storage_client": {
+			"connection_timeout": "5s",
+			"request_timeout": "3s",
+			"endpoints": [
+			"http://127.0.0.1:2379"
+			]
+			}
+		},
+		{
+			"group_name": "default_group",
+			"group_id": "88ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=",
+			"payment_address": "0x671276c61943A35D5F230d076bDFd91B0c47bF09",
+			"payment_channel_storage_type": "etcd",
+			"payment_channel_storage_client": {
+			"connection_timeout": "5s",
+			"request_timeout": "3s",
+			"endpoints": [
+			"http://127.0.0.1:2479"
+			]
+		}
+		}
+]
+}*/
+
+type OrganizationMetaData struct {
+	OrgName string  `json:"org_name"`
+	OrgID   string  `json:"org_id"`
+	Groups  []Group `json:"groups"`
+	//This will used to determine which group the daemon belongs to
+	daemonGroup             *Group
+	daemonReplicaGroupID    [32]byte
+	recipientPaymentAddress common.Address
+}
+
+//Structure to hold the individual group details , an Organization can have multiple groups
+type Group struct {
+	GroupName                   string                      `json:"group_name"`
+	GroupID                     string                      `json:"group_id"`
+	PaymentAddress              string                      `json:"payment_address"`
+	PaymentChannelStorageType   string                      `json:"payment_channel_storage_type"`
+	PaymentChannelStorageClient PaymentChannelStorageClient `json:"payment_channel_storage_client"`
+}
+
+//Structure to hold the storage details of the payment
+type PaymentChannelStorageClient struct {
+	ConnectionTimeout string   `json:"connection_timeout"`
+	RequestTimeout    string   `json:"request_timeout"`
+	Endpoints         []string `json:"endpoints"`
+}
+
+//Get the Group ID the Daemon needs to associate itself to , requests belonging to a different group if will be rejected
+func (orgMetaData OrganizationMetaData) GetGroupId() (groupId string, err error) {
+	if group, err := orgMetaData.getDaemonGroup(); err == nil {
+		return group.GroupID, nil
+	}
+	return groupId, err
+}
+
+//Construct the Organization metadata from the JSON Passed
+func InitOrganizationMetaDataFromJson(jsonData string) (metaData *OrganizationMetaData, err error) {
+	metaData = new(OrganizationMetaData)
+	err = json.Unmarshal([]byte(jsonData), &metaData)
+	if err != nil {
+		log.WithError(err).WithField("jsondata", jsonData)
+		return nil, err
+	}
+
+	if err = setDerivedAttributes(metaData); err != nil {
+		return nil, err
+	}
+
+	return metaData, err
+}
+
+func setDerivedAttributes(metaData *OrganizationMetaData) (err error) {
+	if metaData.daemonGroup, err = metaData.getDaemonGroup(); err != nil {
+		return err
+	}
+	metaData.daemonReplicaGroupID, err = ConvertBase64Encoding(metaData.daemonGroup.GroupID)
+	metaData.recipientPaymentAddress = common.HexToAddress(metaData.daemonGroup.PaymentAddress)
+	return err
+}
+
+//Pass the group Name and retrieve the details of the payment address/ recipient address.
+func (orgMetaData OrganizationMetaData) GetPaymentAddress() (address string) {
+	return orgMetaData.daemonGroup.PaymentAddress
+}
+
+func (orgMetaData OrganizationMetaData) getDaemonGroup() (group *Group, err error) {
+	groupName := config.GetString(config.DaemonGroupName)
+	for _, group := range orgMetaData.Groups {
+		if strings.Compare(group.GroupName, groupName) == 0 {
+			return &group, nil
+		}
+	}
+	return nil, fmt.Errorf("group Name %v in config is invalid, "+
+		"there was no group found with this name in the metadata", groupName)
+}
+
+//Get the End points of the Payment Storage used to update the storage state
+func (orgMetaData OrganizationMetaData) GetPaymentStorageEndPoint() (endpoint []string) {
+	return orgMetaData.daemonGroup.PaymentChannelStorageClient.Endpoints
+}
+
+func (metaData OrganizationMetaData) GetDaemonGroupID() [32]byte {
+	return metaData.daemonReplicaGroupID
+}
+
+//Will be used to load the Organization metadata when Daemon starts
+//To be part of components
+func GetOrganizationMetaData() *OrganizationMetaData {
+	var metadata *OrganizationMetaData
+	var err error
+	if config.GetBool(config.BlockchainEnabledKey) {
+		ipfsHash := string(getOrgMetadataURI())
+		metadata, err = GetOrganizationMetaDataFromIPFS(FormatHash(ipfsHash))
+	}
+	if err != nil {
+		log.WithError(err).
+			Panic("error on determining organization metadata from block chain")
+	}
+	return metadata
+}
+
+func GetOrganizationMetaDataFromIPFS(hash string) (*OrganizationMetaData, error) {
+	jsondata := ipfsutils.GetIpfsFile(hash)
+	return InitOrganizationMetaDataFromJson(jsondata)
+}
+
+//TODO , once the latest contract is pushed , the below method will be called
+func getOrgMetadataURI() []byte {
+	//Block chain call here to get the hash of the metadata for the given Organization
+	reg := getRegistryCaller()
+	orgId := StringToBytes32(config.GetString(config.OrganizationId))
+
+	organizationRegistered, err := reg.GetOrganizationById(nil, orgId)
+	if err != nil || !organizationRegistered.Found {
+		log.WithError(err).WithField("OrganizationId", config.GetString(config.OrganizationId)).
+			WithField("ServiceId", config.GetString(config.ServiceId)).
+			Panic("Error Retrieving contract details for the Given Organization and Service Ids ")
+	}
+
+	//return organizationRegistered.orgMetadataURI[:] //TODO , once the latest version of the registry is published, this line will be uncommented.
+	return nil
+}

--- a/blockchain/orginzationMetadata_test.go
+++ b/blockchain/orginzationMetadata_test.go
@@ -34,4 +34,5 @@ func TestGetOrganizationMetaDataForError(t *testing.T) {
 		assert.Nil(t, metadata)
 		assert.Equal(t, "group name unknow in config is invalid, there was no group found with this name in the metadata", err.Error())
 	}
+	config.Vip().Set(config.DaemonGroupName, "default_group")
 }

--- a/blockchain/orginzationMetadata_test.go
+++ b/blockchain/orginzationMetadata_test.go
@@ -1,23 +1,13 @@
 package blockchain
 
 import (
+	"github.com/singnet/snet-daemon/config"
 	"github.com/stretchr/testify/assert"
+	"math/big"
 	"testing"
 )
 
-var testJsonOrgGroupData = "{\"org_name\":\"organization_name\",\"org_id\":\"org_id1\",\"groups\": [   {\"group_name\":\"group1\",\"group_id\":\"99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",\"payment_address\":\"0x671276c61943A35D5F230d076bDFd91B0c47bF09\",\"payment_channel_storage_type\":\"etcd\",\"payment_channel_storage_client\": {\"connection_timeout\":\"5s\",\"request_timeout\":\"3s\",\"endpoints\": [\"http://127.0.0.1:2379\"    ]    }   },   {\"group_name\":\"default_group\",\"group_id\":\"88ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",\"payment_address\":\"0x671276c61943A35D5F230d076bDFd91B0c47bF09\",\"payment_channel_storage_type\":\"etcd\",\"payment_channel_storage_client\": {\"connection_timeout\":\"5s\",\"request_timeout\":\"3s\",\"endpoints\": [\"http://127.0.0.1:2479\"    ]   }   } ] }"
-
-func TestOrganizationMetaData_GetGroupId(t *testing.T) {
-
-}
-
-func TestInitOrganizationMetaDataFromJson(t *testing.T) {
-
-}
-
-func TestOrganizationMetaData_GetPaymentAddress(t *testing.T) {
-
-}
+var testJsonOrgGroupData = "{   \"org_name\": \"organization_name\",   \"org_id\": \"org_id1\",   \"groups\": [     {       \"group_name\": \"default_group2\",       \"group_id\": \"99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",       \"payment\": {         \"payment_address\": \"0x671276c61943A35D5F230d076bDFd91B0c47bF09\",         \"payment_expiration_threshold\": 40320,         \"payment_channel_storage_type\": \"etcd\",         \"payment_channel_storage_client\": {           \"connection_timeout\": \"5s\",           \"request_timeout\": \"3s\",           \"endpoints\": [             \"http://127.0.0.1:2379\"           ]         }       }     },      {       \"group_name\": \"default_group\",       \"group_id\": \"99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",       \"payment\": {         \"payment_address\": \"0x671276c61943A35D5F230d076bDFd91B0c47bF09\",         \"payment_expiration_threshold\": 40320,         \"payment_channel_storage_type\": \"etcd\",         \"payment_channel_storage_client\": {           \"connection_timeout\": \"5s\",           \"request_timeout\": \"3s\",           \"endpoints\": [             \"http://127.0.0.1:2379\"           ]         }       }     }   ] }"
 
 func TestGetOrganizationMetaData(t *testing.T) {
 	metadata, err := InitOrganizationMetaDataFromJson(testJsonOrgGroupData)
@@ -26,13 +16,22 @@ func TestGetOrganizationMetaData(t *testing.T) {
 	assert.Equal(t, "organization_name", metadata.OrgName)
 	address := metadata.GetPaymentAddress()
 	assert.Equal(t, "0x671276c61943A35D5F230d076bDFd91B0c47bF09", address)
+	assert.Equal(t, "http://127.0.0.1:2379", metadata.GetPaymentStorageEndPoint()[0])
+	assert.Equal(t, "99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=", metadata.GetGroupIdString())
+	assert.Equal(t, big.NewInt(40320), metadata.GetPaymentExpirationThreshold())
+	grpId, _ := ConvertBase64Encoding("99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=")
+	assert.Equal(t, grpId, metadata.GetGroupId())
 
 }
 
-func TestGetOrganizationMetaDataFromIPFS(t *testing.T) {
+func TestGetOrganizationMetaDataForError(t *testing.T) {
+	metadata, err := InitOrganizationMetaDataFromJson("bad json")
+	assert.Nil(t, metadata)
+	assert.NotNil(t, err)
 
-}
-
-func Test_getOrgMetadataURI(t *testing.T) {
-
+	config.Vip().Set(config.DaemonGroupName, "unknow")
+	if metadata, err = InitOrganizationMetaDataFromJson(testJsonOrgGroupData); err != nil {
+		assert.Nil(t, metadata)
+		assert.Equal(t, "group name unknow in config is invalid, there was no group found with this name in the metadata", err.Error())
+	}
 }

--- a/blockchain/orginzationMetadata_test.go
+++ b/blockchain/orginzationMetadata_test.go
@@ -1,0 +1,38 @@
+package blockchain
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var testJsonOrgGroupData = "{\"org_name\":\"organization_name\",\"org_id\":\"org_id1\",\"groups\": [   {\"group_name\":\"group1\",\"group_id\":\"99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",\"payment_address\":\"0x671276c61943A35D5F230d076bDFd91B0c47bF09\",\"payment_channel_storage_type\":\"etcd\",\"payment_channel_storage_client\": {\"connection_timeout\":\"5s\",\"request_timeout\":\"3s\",\"endpoints\": [\"http://127.0.0.1:2379\"    ]    }   },   {\"group_name\":\"default_group\",\"group_id\":\"88ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",\"payment_address\":\"0x671276c61943A35D5F230d076bDFd91B0c47bF09\",\"payment_channel_storage_type\":\"etcd\",\"payment_channel_storage_client\": {\"connection_timeout\":\"5s\",\"request_timeout\":\"3s\",\"endpoints\": [\"http://127.0.0.1:2479\"    ]   }   } ] }"
+
+func TestOrganizationMetaData_GetGroupId(t *testing.T) {
+
+}
+
+func TestInitOrganizationMetaDataFromJson(t *testing.T) {
+
+}
+
+func TestOrganizationMetaData_GetPaymentAddress(t *testing.T) {
+
+}
+
+func TestGetOrganizationMetaData(t *testing.T) {
+	metadata, err := InitOrganizationMetaDataFromJson(testJsonOrgGroupData)
+	assert.Nil(t, err)
+	assert.NotNil(t, metadata)
+	assert.Equal(t, "organization_name", metadata.OrgName)
+	address := metadata.GetPaymentAddress()
+	assert.Equal(t, "0x671276c61943A35D5F230d076bDFd91B0c47bF09", address)
+
+}
+
+func TestGetOrganizationMetaDataFromIPFS(t *testing.T) {
+
+}
+
+func Test_getOrgMetadataURI(t *testing.T) {
+
+}

--- a/blockchain/serviceMetadata.go
+++ b/blockchain/serviceMetadata.go
@@ -91,11 +91,17 @@ func ReadServiceMetaDataFromLocalFile(filename string) (*ServiceMetadata, error)
 	return metadata, nil
 }
 
-func getRegistryCaller() *RegistryCaller {
+func getRegistryCaller() (reg *RegistryCaller) {
 	ethClient, err := GetEthereumClient()
+	if err != nil {
+
+		log.WithError(err).
+			Panic("Unable to get Blockchain client ")
+
+	}
 	defer ethClient.Close()
 	registryContractAddress := getRegistryAddressKey()
-	reg, err := NewRegistryCaller(registryContractAddress, ethClient.EthClient)
+	reg, err = NewRegistryCaller(registryContractAddress, ethClient.EthClient)
 	if err != nil {
 		log.WithError(err).WithField("registryContractAddress", registryContractAddress).
 			Panic("Error instantiating Registry contract for the given Contract Address")
@@ -105,6 +111,7 @@ func getRegistryCaller() *RegistryCaller {
 
 func getServiceMetaDataUrifromRegistry() []byte {
 	reg := getRegistryCaller()
+
 	orgId := StringToBytes32(config.GetString(config.OrganizationId))
 	serviceId := StringToBytes32(config.GetString(config.ServiceId))
 


### PR DESCRIPTION
As part of Supporting a single channel per Organization per Group (Payment Group across the services)  we will need all the services to share the same channel state. We need to standardize what this state is across all services belonging to the same group.

Please note , more PR will follow to remove data points being used from service metadata and replace them with data from Organization metadata