### PR TITLE
Capture additional user details in Daemon Metrics 

### DIFF
--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -11,19 +11,6 @@ import (
 )
 
 const (
-	// PaymentChannelIDHeader is a MultiPartyEscrow contract payment channel
-	// id. Value is a string containing a decimal number.
-	PaymentChannelIDHeader = "snet-payment-channel-id"
-	// PaymentChannelNonceHeader is a payment channel nonce value. Value is a
-	// string containing a decimal number.
-	PaymentChannelNonceHeader = "snet-payment-channel-nonce"
-	// PaymentChannelAmountHeader is an amount of payment channel value
-	// which server is authorized to withdraw after handling the RPC call.
-	// Value is a string containing a decimal number.
-	PaymentChannelAmountHeader = "snet-payment-channel-amount"
-	// PaymentChannelSignatureHeader is a signature of the client to confirm
-	// amount withdrawing authorization. Value is an array of bytes.
-	PaymentChannelSignatureHeader = "snet-payment-channel-signature-bin"
 
 	// EscrowPaymentType each call should have id and nonce of payment channel
 	// in metadata.
@@ -76,22 +63,22 @@ func (h *paymentChannelPaymentHandler) Payment(context *handler.GrpcStreamContex
 }
 
 func (h *paymentChannelPaymentHandler) getPaymentFromContext(context *handler.GrpcStreamContext) (payment *Payment, err *handler.GrpcError) {
-	channelID, err := handler.GetBigInt(context.MD, PaymentChannelIDHeader)
+	channelID, err := handler.GetBigInt(context.MD, handler.PaymentChannelIDHeader)
 	if err != nil {
 		return
 	}
 
-	channelNonce, err := handler.GetBigInt(context.MD, PaymentChannelNonceHeader)
+	channelNonce, err := handler.GetBigInt(context.MD, handler.PaymentChannelNonceHeader)
 	if err != nil {
 		return
 	}
 
-	amount, err := handler.GetBigInt(context.MD, PaymentChannelAmountHeader)
+	amount, err := handler.GetBigInt(context.MD, handler.PaymentChannelAmountHeader)
 	if err != nil {
 		return
 	}
 
-	signature, err := handler.GetBytes(context.MD, PaymentChannelSignatureHeader)
+	signature, err := handler.GetBytes(context.MD, handler.PaymentChannelSignatureHeader)
 	if err != nil {
 		return
 	}

--- a/escrow/payment_handler_test.go
+++ b/escrow/payment_handler_test.go
@@ -51,10 +51,10 @@ func (suite *PaymentHandlerTestSuite) channel() *PaymentChannelData {
 func (suite *PaymentHandlerTestSuite) grpcMetadata(channelID, channelNonce, amount int64, signature []byte) metadata.MD {
 	md := metadata.New(map[string]string{})
 
-	md.Set(PaymentChannelIDHeader, strconv.FormatInt(channelID, 10))
-	md.Set(PaymentChannelNonceHeader, strconv.FormatInt(channelNonce, 10))
-	md.Set(PaymentChannelAmountHeader, strconv.FormatInt(amount, 10))
-	md.Set(PaymentChannelSignatureHeader, string(signature))
+	md.Set(handler.PaymentChannelIDHeader, strconv.FormatInt(channelID, 10))
+	md.Set(handler.PaymentChannelNonceHeader, strconv.FormatInt(channelNonce, 10))
+	md.Set(handler.PaymentChannelAmountHeader, strconv.FormatInt(amount, 10))
+	md.Set(handler.PaymentChannelSignatureHeader, string(signature))
 
 	return md
 }
@@ -77,7 +77,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPayment() {
 
 func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelId() {
 	context := suite.grpcContext(func(md *metadata.MD) {
-		delete(*md, PaymentChannelIDHeader)
+		delete(*md, handler.PaymentChannelIDHeader)
 	})
 
 	payment, err := suite.paymentHandler.Payment(context)
@@ -88,7 +88,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelId() {
 
 func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelNonce() {
 	context := suite.grpcContext(func(md *metadata.MD) {
-		delete(*md, PaymentChannelNonceHeader)
+		delete(*md, handler.PaymentChannelNonceHeader)
 	})
 
 	payment, err := suite.paymentHandler.Payment(context)
@@ -99,7 +99,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelNonce() {
 
 func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelAmount() {
 	context := suite.grpcContext(func(md *metadata.MD) {
-		delete(*md, PaymentChannelAmountHeader)
+		delete(*md, handler.PaymentChannelAmountHeader)
 	})
 
 	payment, err := suite.paymentHandler.Payment(context)
@@ -110,7 +110,7 @@ func (suite *PaymentHandlerTestSuite) TestGetPaymentNoChannelAmount() {
 
 func (suite *PaymentHandlerTestSuite) TestGetPaymentNoSignature() {
 	context := suite.grpcContext(func(md *metadata.MD) {
-		delete(*md, PaymentChannelSignatureHeader)
+		delete(*md, handler.PaymentChannelSignatureHeader)
 	})
 
 	payment, err := suite.paymentHandler.Payment(context)

--- a/handler/interceptors.go
+++ b/handler/interceptors.go
@@ -22,6 +22,25 @@ const (
 	// Supported types are: "escrow".
 	// Note: "job" Payment type is deprecated
 	PaymentTypeHeader = "snet-payment-type"
+	//Client that calls the Daemon ( example can be "snet-cli","snet-dapp","snet-sdk")
+	ClientTypeHeader = "snet-client-type"
+	//Value is a user address , example "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207"
+	UserInfoHeader = "snet-user-info"
+	//User Agent details set in on the server stream info
+	UserAgentHeader = "user-agent"
+	// PaymentChannelIDHeader is a MultiPartyEscrow contract payment channel
+	// id. Value is a string containing a decimal number.
+	PaymentChannelIDHeader = "snet-payment-channel-id"
+	// PaymentChannelNonceHeader is a payment channel nonce value. Value is a
+	// string containing a decimal number.
+	PaymentChannelNonceHeader = "snet-payment-channel-nonce"
+	// PaymentChannelAmountHeader is an amount of payment channel value
+	// which server is authorized to withdraw after handling the RPC call.
+	// Value is a string containing a decimal number.
+	PaymentChannelAmountHeader = "snet-payment-channel-amount"
+	// PaymentChannelSignatureHeader is a signature of the client to confirm
+	// amount withdrawing authorization. Value is an array of bytes.
+	PaymentChannelSignatureHeader = "snet-payment-channel-signature-bin"
 )
 
 // GrpcStreamContext contains information about gRPC call which is used to
@@ -83,7 +102,6 @@ func NewGrpcErrorf(code codes.Code, format string, args ...interface{}) *GrpcErr
 	}
 }
 
-
 // PaymentHandler interface which is used by gRPC interceptor to get, validate
 // and complete payment. There are two payment handler implementations so far:
 // jobPaymentHandler and escrowPaymentHandler. jobPaymentHandler is depreactted.
@@ -137,8 +155,13 @@ func interceptMonitoring(srv interface{}, ss grpc.ServerStream, info *grpc.Strea
 	start = time.Now()
 	//Get the method name
 	methodName, _ := grpc.MethodFromServerStream(ss)
+	//Get the Context
+
 	//Build common stats and use this to set request stats and response stats
 	commonStats := metrics.BuildCommonStats(start, methodName)
+	if context, err := getGrpcContext(ss, info); err == nil {
+		setAdditionalDetails(context, commonStats)
+	}
 	go metrics.PublishRequestStats(commonStats, ss)
 	defer func() {
 		go metrics.PublishResponseStats(commonStats, time.Now().Sub(start), e)
@@ -333,4 +356,21 @@ func GetSingleValue(md metadata.MD, key string) (value string, err *GrpcError) {
 func NoOpInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler) error {
 	return handler(srv, ss)
+}
+
+//set Additional details on the metrics persisted , this is to keep track of how many calls were made per channel
+func setAdditionalDetails(context *GrpcStreamContext, stats *metrics.CommonStats) {
+	md := context.MD
+	if str, err := GetSingleValue(md, ClientTypeHeader); err == nil {
+		stats.ClientType = str
+	}
+	if str, err := GetSingleValue(md, UserInfoHeader); err == nil {
+		stats.UserDetails = str
+	}
+	if str, err := GetSingleValue(md, UserAgentHeader); err == nil {
+		stats.UserAgent = str
+	}
+	if str, err := GetSingleValue(md, PaymentChannelIDHeader); err == nil {
+		stats.ChannelId = str
+	}
 }

--- a/metrics/request_stats.go
+++ b/metrics/request_stats.go
@@ -24,6 +24,7 @@ type RequestStats struct {
 	ClientType                 string `json:"client_type"`
 	UserDetails                string `json:"user_details"`
 	UserAgent                  string `json:"user_agent"`
+	ChannelId                  string `json:"channel_id"`
 }
 
 //Create a request Object and Publish this to a service end point
@@ -56,6 +57,7 @@ func createRequestStat(commonStat *CommonStats) *RequestStats {
 		ClientType:                 commonStat.ClientType,
 		UserDetails:                commonStat.UserDetails,
 		UserAgent:                  commonStat.UserAgent,
+		ChannelId:                  commonStat.ChannelId,
 	}
 	return request
 }

--- a/metrics/request_stats.go
+++ b/metrics/request_stats.go
@@ -21,6 +21,9 @@ type RequestStats struct {
 	GroupID                    string `json:"group_id"`
 	DaemonEndPoint             string `json:"daemon_end_point"`
 	Version                    string `json:"version"`
+	ClientType                 string `json:"client_type"`
+	UserDetails                string `json:"user_details"`
+	UserAgent                  string `json:"user_agent"`
 }
 
 //Create a request Object and Publish this to a service end point
@@ -50,6 +53,9 @@ func createRequestStat(commonStat *CommonStats) *RequestStats {
 		RequestReceivedTime:        commonStat.RequestReceivedTime,
 		ServiceMethod:              commonStat.ServiceMethod,
 		Version:                    commonStat.Version,
+		ClientType:                 commonStat.ClientType,
+		UserDetails:                commonStat.UserDetails,
+		UserAgent:                  commonStat.UserAgent,
 	}
 	return request
 }

--- a/metrics/request_stats_test.go
+++ b/metrics/request_stats_test.go
@@ -17,6 +17,9 @@ func TestSetDataFromContext(t *testing.T) {
 func TestCreateRequestStat(t *testing.T) {
 	arrivalTime := time.Now()
 	commonStat := BuildCommonStats(arrivalTime, "TestMethod")
+	commonStat.ClientType = "snet-cli"
+	commonStat.UserDetails = "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207"
+	commonStat.UserAgent = "python/cli"
 	request := createRequestStat(commonStat)
 	assert.Equal(t, request.RequestID, commonStat.ID)
 	assert.Equal(t, request.GroupID, daemonGroupId)
@@ -25,4 +28,7 @@ func TestCreateRequestStat(t *testing.T) {
 	assert.Equal(t, request.RequestReceivedTime, arrivalTime.String())
 	assert.Equal(t, request.Version, commonStat.Version)
 	assert.Equal(t, request.Type, "request")
+	assert.Equal(t, request.ClientType, "snet-cli")
+	assert.Equal(t, request.UserDetails, "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207")
+	assert.Equal(t, request.UserAgent, "python/cli")
 }

--- a/metrics/request_stats_test.go
+++ b/metrics/request_stats_test.go
@@ -20,6 +20,7 @@ func TestCreateRequestStat(t *testing.T) {
 	commonStat.ClientType = "snet-cli"
 	commonStat.UserDetails = "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207"
 	commonStat.UserAgent = "python/cli"
+	commonStat.ChannelId =  "2"
 	request := createRequestStat(commonStat)
 	assert.Equal(t, request.RequestID, commonStat.ID)
 	assert.Equal(t, request.GroupID, daemonGroupId)
@@ -31,5 +32,5 @@ func TestCreateRequestStat(t *testing.T) {
 	assert.Equal(t, request.ClientType, "snet-cli")
 	assert.Equal(t, request.UserDetails, "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207")
 	assert.Equal(t, request.UserAgent, "python/cli")
-	assert.Equal(t, request.ChannelId, "1")
+	assert.Equal(t, request.ChannelId, "2")
 }

--- a/metrics/request_stats_test.go
+++ b/metrics/request_stats_test.go
@@ -31,4 +31,5 @@ func TestCreateRequestStat(t *testing.T) {
 	assert.Equal(t, request.ClientType, "snet-cli")
 	assert.Equal(t, request.UserDetails, "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207")
 	assert.Equal(t, request.UserAgent, "python/cli")
+	assert.Equal(t, request.ChannelId, "1")
 }

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -20,6 +20,7 @@ type CommonStats struct {
 	ClientType          string
 	UserDetails         string
 	UserAgent           string
+	ChannelId           string
 }
 
 func BuildCommonStats(receivedTime time.Time, methodName string) *CommonStats {
@@ -58,6 +59,7 @@ type ResponseStats struct {
 	ClientType                 string `json:"client_type"`
 	UserDetails                string `json:"user_details"`
 	UserAgent                  string `json:"user_agent"`
+	ChannelId                  string `json:"channel_id"`
 }
 
 //Publish response received as a payload for reporting /metrics analysis
@@ -86,6 +88,7 @@ func createResponseStats(commonStat *CommonStats, duration time.Duration, err er
 		ClientType:                 commonStat.ClientType,
 		UserDetails:                commonStat.UserDetails,
 		UserAgent:                  commonStat.UserAgent,
+		ChannelId:                  commonStat.ChannelId,
 	}
 	return response
 }

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -32,9 +32,6 @@ func BuildCommonStats(receivedTime time.Time, methodName string) *CommonStats {
 		ServiceID:           config.GetString(config.ServiceId),
 		ServiceMethod:       methodName,
 		Version:             config.GetVersionTag(),
-		ClientType:          "",
-		UserDetails:         "",
-		UserAgent:           "",
 	}
 	return commonStats
 

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -17,6 +17,9 @@ type CommonStats struct {
 	GroupID             string
 	DaemonEndPoint      string
 	Version             string
+	ClientType          string
+	UserDetails         string
+	UserAgent           string
 }
 
 func BuildCommonStats(receivedTime time.Time, methodName string) *CommonStats {
@@ -28,6 +31,9 @@ func BuildCommonStats(receivedTime time.Time, methodName string) *CommonStats {
 		ServiceID:           config.GetString(config.ServiceId),
 		ServiceMethod:       methodName,
 		Version:             config.GetVersionTag(),
+		ClientType:          "",
+		UserDetails:         "",
+		UserAgent:           "",
 	}
 	return commonStats
 
@@ -49,6 +55,9 @@ type ResponseStats struct {
 	ResponseCode               string `json:"response_code"`
 	ErrorMessage               string `json:"error_message"`
 	Version                    string `json:"version"`
+	ClientType                 string `json:"client_type"`
+	UserDetails                string `json:"user_details"`
+	UserAgent                  string `json:"user_agent"`
 }
 
 //Publish response received as a payload for reporting /metrics analysis
@@ -74,6 +83,9 @@ func createResponseStats(commonStat *CommonStats, duration time.Duration, err er
 		ErrorMessage:               getErrorMessage(err),
 		ResponseCode:               getErrorCode(err),
 		Version:                    commonStat.Version,
+		ClientType:                 commonStat.ClientType,
+		UserDetails:                commonStat.UserDetails,
+		UserAgent:                  commonStat.UserAgent,
 	}
 	return response
 }

--- a/metrics/response_stats_test.go
+++ b/metrics/response_stats_test.go
@@ -14,6 +14,7 @@ func TestCreateResponseStats(t *testing.T) {
 	commonStat.ClientType = "snet-cli"
 	commonStat.UserDetails = "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207"
 	commonStat.UserAgent = "python/cli"
+	commonStat.ChannelId = "1"
 	response := createResponseStats(commonStat, time.Duration(1234566000), nil)
 	assert.Equal(t, response.RequestID, commonStat.ID)
 	assert.Equal(t, response.Version, commonStat.Version)
@@ -24,6 +25,7 @@ func TestCreateResponseStats(t *testing.T) {
 	assert.Equal(t, response.ClientType, "snet-cli")
 	assert.Equal(t, response.UserDetails, "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207")
 	assert.Equal(t, response.UserAgent, "python/cli")
+	assert.Equal(t, response.ChannelId, "1")
 }
 
 func TestGetErrorMessage(t *testing.T) {

--- a/metrics/response_stats_test.go
+++ b/metrics/response_stats_test.go
@@ -11,6 +11,9 @@ import (
 func TestCreateResponseStats(t *testing.T) {
 	arrivalTime := time.Now()
 	commonStat := BuildCommonStats(arrivalTime, "TestMethod")
+	commonStat.ClientType = "snet-cli"
+	commonStat.UserDetails = "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207"
+	commonStat.UserAgent = "python/cli"
 	response := createResponseStats(commonStat, time.Duration(1234566000), nil)
 	assert.Equal(t, response.RequestID, commonStat.ID)
 	assert.Equal(t, response.Version, commonStat.Version)
@@ -18,6 +21,9 @@ func TestCreateResponseStats(t *testing.T) {
 	assert.Equal(t, response.ResponseTime, "1.2346")
 	assert.Equal(t, response.Type, "response")
 	assert2.NotEqual(t, response.ResponseSentTime, "")
+	assert.Equal(t, response.ClientType, "snet-cli")
+	assert.Equal(t, response.UserDetails, "0x94d04332C4f5273feF69c4a52D24f42a3aF1F207")
+	assert.Equal(t, response.UserAgent, "python/cli")
 }
 
 func TestGetErrorMessage(t *testing.T) {


### PR DESCRIPTION
#322 
Details like thebelow will be set by the respective clients and added to the Daemon metrics 

- type of client calling Deamon ( ex Snet-cli, Dapp, SDK) , these will be set by the respective clients 
- user adderss
