### PR TITLE
Issue 340: Correct the mockable url of Daemon 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net/url"
 	"net"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -17,14 +17,14 @@ import (
 )
 
 const (
-    //Contains the Authentication address that will be used to validate all requests to update Daemon configuration remotely through a user interface
-	AuthenticationAddress= "authentication_address"
-	AutoSSLDomainKey     = "auto_ssl_domain"
-	AutoSSLCacheDirKey   = "auto_ssl_cache_dir"
-	BlockchainEnabledKey = "blockchain_enabled"
-	BlockChainNetworkSelected      = "blockchain_network_selected"
-	BurstSize            = "burst_size"
-	ConfigPathKey        = "config_path"
+	//Contains the Authentication address that will be used to validate all requests to update Daemon configuration remotely through a user interface
+	AuthenticationAddress     = "authentication_address"
+	AutoSSLDomainKey          = "auto_ssl_domain"
+	AutoSSLCacheDirKey        = "auto_ssl_cache_dir"
+	BlockchainEnabledKey      = "blockchain_enabled"
+	BlockChainNetworkSelected = "blockchain_network_selected"
+	BurstSize                 = "burst_size"
+	ConfigPathKey             = "config_path"
 
 	DaemonGroupName                = "daemon_group_name"
 	DaemonTypeKey                  = "daemon_type"
@@ -52,7 +52,7 @@ const (
 	NotificationServiceEndpoint = "notification_svc_end_point"
 	ServiceHeartbeatType        = "service_heartbeat_type"
 	//none|grpc|http
-//This defaultConfigJson will eventually be replaced by DefaultDaemonConfigurationSchema
+	//This defaultConfigJson will eventually be replaced by DefaultDaemonConfigurationSchema
 	defaultConfigJson string = `
 {
 	"auto_ssl_domain": "",
@@ -112,9 +112,8 @@ const (
 		"enabled": true
 	},
 	"alerts_email": "", 
-	"service_heartbeat_type": "http",
-	"heartbeat_svc_end_point": "http://demo3208027.mockable.io/heartbeat",
-	"notification_svc_end_point": "http://demo3208027.mockable.io"
+	"service_heartbeat_type": "http"
+	
 }
 `
 )
@@ -188,17 +187,16 @@ func Validate() error {
 	}
 
 	//Check if the Daemon is on the latest version or not
-	if message,err := CheckVersionOfDaemon(); err != nil {
+	if message, err := CheckVersionOfDaemon(); err != nil {
 		//In case of any error on version check , just log it
 		log.Warning(err)
-	}else {
+	} else {
 		log.Info(message)
 	}
 
-
 	// the maximum that the server can receive to 2GB.
-	maxMessageSize:= vip.GetInt(MaxMessageSizeInMB)
-	if ( maxMessageSize <=0 || maxMessageSize > 2048)   {
+	maxMessageSize := vip.GetInt(MaxMessageSizeInMB)
+	if maxMessageSize <= 0 || maxMessageSize > 2048 {
 		return errors.New(" max_message_size_in_mb cannot be more than 2GB (i.e 2048 MB) and has to be a positive number")
 	}
 
@@ -253,7 +251,6 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	return sub
 }
 
-
 func LogConfig() {
 	log.Info("Final configuration:")
 	keys := vip.AllKeys()
@@ -300,9 +297,9 @@ func ValidateEndpoints(daemonEndpoint string, passthroughEndpoint string) error 
 		return errors.New("passthrough endpoint can't be the same as daemon endpoint!")
 	}
 
-	if ((daemonPort == passthroughURL.Port()) &&
-	    (daemonHost == "0.0.0.0") &&
-	    (passthroughURL.Hostname() == "127.0.0.1" || passthroughURL.Hostname() == "localhost"))	{
+	if (daemonPort == passthroughURL.Port()) &&
+		(daemonHost == "0.0.0.0") &&
+		(passthroughURL.Hostname() == "127.0.0.1" || passthroughURL.Hostname() == "localhost") {
 		return errors.New("passthrough endpoint can't be the same as daemon endpoint!")
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net"
 	"net/url"
+	"net"
 	"regexp"
 	"sort"
 	"strings"
@@ -17,14 +17,14 @@ import (
 )
 
 const (
-	//Contains the Authentication address that will be used to validate all requests to update Daemon configuration remotely through a user interface
-	AuthenticationAddress     = "authentication_address"
-	AutoSSLDomainKey          = "auto_ssl_domain"
-	AutoSSLCacheDirKey        = "auto_ssl_cache_dir"
-	BlockchainEnabledKey      = "blockchain_enabled"
-	BlockChainNetworkSelected = "blockchain_network_selected"
-	BurstSize                 = "burst_size"
-	ConfigPathKey             = "config_path"
+    //Contains the Authentication address that will be used to validate all requests to update Daemon configuration remotely through a user interface
+	AuthenticationAddress= "authentication_address"
+	AutoSSLDomainKey     = "auto_ssl_domain"
+	AutoSSLCacheDirKey   = "auto_ssl_cache_dir"
+	BlockchainEnabledKey = "blockchain_enabled"
+	BlockChainNetworkSelected      = "blockchain_network_selected"
+	BurstSize            = "burst_size"
+	ConfigPathKey        = "config_path"
 
 	DaemonGroupName                = "daemon_group_name"
 	DaemonTypeKey                  = "daemon_type"
@@ -52,7 +52,7 @@ const (
 	NotificationServiceEndpoint = "notification_svc_end_point"
 	ServiceHeartbeatType        = "service_heartbeat_type"
 	//none|grpc|http
-	//This defaultConfigJson will eventually be replaced by DefaultDaemonConfigurationSchema
+//This defaultConfigJson will eventually be replaced by DefaultDaemonConfigurationSchema
 	defaultConfigJson string = `
 {
 	"auto_ssl_domain": "",
@@ -113,7 +113,7 @@ const (
 	},
 	"alerts_email": "", 
 	"service_heartbeat_type": "http"
-	
+
 }
 `
 )
@@ -187,16 +187,17 @@ func Validate() error {
 	}
 
 	//Check if the Daemon is on the latest version or not
-	if message, err := CheckVersionOfDaemon(); err != nil {
+	if message,err := CheckVersionOfDaemon(); err != nil {
 		//In case of any error on version check , just log it
 		log.Warning(err)
-	} else {
+	}else {
 		log.Info(message)
 	}
 
+
 	// the maximum that the server can receive to 2GB.
-	maxMessageSize := vip.GetInt(MaxMessageSizeInMB)
-	if maxMessageSize <= 0 || maxMessageSize > 2048 {
+	maxMessageSize:= vip.GetInt(MaxMessageSizeInMB)
+	if ( maxMessageSize <=0 || maxMessageSize > 2048)   {
 		return errors.New(" max_message_size_in_mb cannot be more than 2GB (i.e 2048 MB) and has to be a positive number")
 	}
 
@@ -251,6 +252,7 @@ func SubWithDefault(config *viper.Viper, key string) *viper.Viper {
 	return sub
 }
 
+
 func LogConfig() {
 	log.Info("Final configuration:")
 	keys := vip.AllKeys()
@@ -297,9 +299,9 @@ func ValidateEndpoints(daemonEndpoint string, passthroughEndpoint string) error 
 		return errors.New("passthrough endpoint can't be the same as daemon endpoint!")
 	}
 
-	if (daemonPort == passthroughURL.Port()) &&
-		(daemonHost == "0.0.0.0") &&
-		(passthroughURL.Hostname() == "127.0.0.1" || passthroughURL.Hostname() == "localhost") {
+	if ((daemonPort == passthroughURL.Port()) &&
+	    (daemonHost == "0.0.0.0") &&
+	    (passthroughURL.Hostname() == "127.0.0.1" || passthroughURL.Hostname() == "localhost"))	{
 		return errors.New("passthrough endpoint can't be the same as daemon endpoint!")
 	}
 	return nil

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -164,8 +164,8 @@ This is the sample configuration to enable metrics and heartbeat
 ```json
   {
       "monitoring_enabled"        : true,
-      "monitoring_svc_end_point"  : "http://demo3208027.mockable.io/metrics",
-      "notification_svc_end_point": "http://demo3208027.mockable.io/notify",
+      "monitoring_svc_end_point"  : "http://demo8325345.mockable.io/metrics",
+      "notification_svc_end_point": "http://demo8325345.mockable.io/notify",
       "alerts_email"               : "xyz.abc@myorg.io",
       "service_heartbeat_type"    : "http",
       "heartbeat_svc_end_point"   : "http://localhost:25000/heartbeat"  

--- a/metrics/clients_test.go
+++ b/metrics/clients_test.go
@@ -26,15 +26,14 @@ const (
 )
 
 type clientImplHeartBeat struct {
-
 }
 
 // Check implements `service Health`.
-func (service *clientImplHeartBeat) Check( ctx context.Context, req *pb.HealthCheckRequest) (*pb.HealthCheckResponse, error) {
-		return &pb.HealthCheckResponse{Status:pb.HealthCheckResponse_SERVING},nil
+func (service *clientImplHeartBeat) Check(ctx context.Context, req *pb.HealthCheckRequest) (*pb.HealthCheckResponse, error) {
+	return &pb.HealthCheckResponse{Status: pb.HealthCheckResponse_SERVING}, nil
 }
 
-func (service *clientImplHeartBeat) Watch(*pb.HealthCheckRequest, pb.Health_WatchServer) (error) {
+func (service *clientImplHeartBeat) Watch(*pb.HealthCheckRequest, pb.Health_WatchServer) error {
 	return nil
 }
 
@@ -63,7 +62,7 @@ func Test_callgRPCServiceHeartbeat(t *testing.T) {
 	assert.False(t, err != nil)
 
 	assert.NotEqual(t, `{}`, string(heartbeat), "Service Heartbeat must not be empty.")
-	assert.Equal(t,heartbeat.String(),pb.HealthCheckResponse_SERVING.String())
+	assert.Equal(t, heartbeat.String(), pb.HealthCheckResponse_SERVING.String())
 
 	serviceURL = "localhost:26000"
 	heartbeat, err = callgRPCServiceHeartbeat(serviceURL)
@@ -71,31 +70,31 @@ func Test_callgRPCServiceHeartbeat(t *testing.T) {
 }
 
 func Test_callHTTPServiceHeartbeat(t *testing.T) {
-	serviceURL := "http://demo3208027.mockable.io/heartbeat"
+	serviceURL := "http://demo8325345.mockable.io/heartbeat"
 	heartbeat, err := callHTTPServiceHeartbeat(serviceURL)
 	assert.False(t, err != nil)
 	assert.NotEqual(t, string(heartbeat), `{}`, "Service Heartbeat must not be empty.")
 	assert.Equal(t, string(heartbeat), `{"serviceID":"SERVICE001", "status":"SERVING"}`,
 		"Unexpected service heartbeat")
 
-/*	var sHeartbeat pb.HeartbeatMsg
-	err = json.Unmarshal(heartbeat, &sHeartbeat)
-	assert.True(t, err != nil)
-	assert.Equal(t, sHeartbeat.ServiceID, "SERVICE001", "Unexpected service ID")
+	/*	var sHeartbeat pb.HeartbeatMsg
+		err = json.Unmarshal(heartbeat, &sHeartbeat)
+		assert.True(t, err != nil)
+		assert.Equal(t, sHeartbeat.ServiceID, "SERVICE001", "Unexpected service ID")
 
-*/	serviceURL = "http://demo3208027.mockable.io"
+	*/serviceURL = "http://demo8325345.mockable.io"
 	heartbeat, err = callHTTPServiceHeartbeat(serviceURL)
 	assert.True(t, err != nil)
 }
 
 func Test_callRegisterService(t *testing.T) {
-	serviceURL := "https://demo3208027.mockable.io/register"
+	serviceURL := "https://demo8325345.mockable.io/register"
 	daemonID := GetDaemonID()
 
 	result := callRegisterService(daemonID, serviceURL)
 	assert.Equal(t, true, result)
 
-	serviceURL = "https://demo3208027.mockable.io/registererror"
+	serviceURL = "https://demo8325345.mockable.io/registererror"
 	result = callRegisterService(daemonID, serviceURL)
 	assert.Equal(t, false, result)
 

--- a/metrics/clients_test.go
+++ b/metrics/clients_test.go
@@ -26,14 +26,15 @@ const (
 )
 
 type clientImplHeartBeat struct {
+
 }
 
 // Check implements `service Health`.
-func (service *clientImplHeartBeat) Check(ctx context.Context, req *pb.HealthCheckRequest) (*pb.HealthCheckResponse, error) {
-	return &pb.HealthCheckResponse{Status: pb.HealthCheckResponse_SERVING}, nil
+func (service *clientImplHeartBeat) Check( ctx context.Context, req *pb.HealthCheckRequest) (*pb.HealthCheckResponse, error) {
+		return &pb.HealthCheckResponse{Status:pb.HealthCheckResponse_SERVING},nil
 }
 
-func (service *clientImplHeartBeat) Watch(*pb.HealthCheckRequest, pb.Health_WatchServer) error {
+func (service *clientImplHeartBeat) Watch(*pb.HealthCheckRequest, pb.Health_WatchServer) (error) {
 	return nil
 }
 
@@ -62,7 +63,7 @@ func Test_callgRPCServiceHeartbeat(t *testing.T) {
 	assert.False(t, err != nil)
 
 	assert.NotEqual(t, `{}`, string(heartbeat), "Service Heartbeat must not be empty.")
-	assert.Equal(t, heartbeat.String(), pb.HealthCheckResponse_SERVING.String())
+	assert.Equal(t,heartbeat.String(),pb.HealthCheckResponse_SERVING.String())
 
 	serviceURL = "localhost:26000"
 	heartbeat, err = callgRPCServiceHeartbeat(serviceURL)
@@ -77,12 +78,12 @@ func Test_callHTTPServiceHeartbeat(t *testing.T) {
 	assert.Equal(t, string(heartbeat), `{"serviceID":"SERVICE001", "status":"SERVING"}`,
 		"Unexpected service heartbeat")
 
-	/*	var sHeartbeat pb.HeartbeatMsg
-		err = json.Unmarshal(heartbeat, &sHeartbeat)
-		assert.True(t, err != nil)
-		assert.Equal(t, sHeartbeat.ServiceID, "SERVICE001", "Unexpected service ID")
+/*	var sHeartbeat pb.HeartbeatMsg
+	err = json.Unmarshal(heartbeat, &sHeartbeat)
+	assert.True(t, err != nil)
+	assert.Equal(t, sHeartbeat.ServiceID, "SERVICE001", "Unexpected service ID")
 
-	*/serviceURL = "http://demo8325345.mockable.io"
+*/	serviceURL = "http://demo8325345.mockable.io"
 	heartbeat, err = callHTTPServiceHeartbeat(serviceURL)
 	assert.True(t, err != nil)
 }

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -44,23 +44,23 @@ func TestHeartbeatHandler(t *testing.T) {
 	assert.False(t, err != nil)
 	assert.NotNil(t, dHeartbeat, "heartbeat must not be nil")
 
-	assert.Equal(t, dHeartbeat.Status, Online.String(), "Invalid State")
+	assert.Equal(t, dHeartbeat.Status, Warning.String(), "Invalid State")
 	assert.NotEqual(t, dHeartbeat.Status, Offline.String(), "Invalid State")
 
 	assert.Equal(t, dHeartbeat.DaemonID, "f940de0eb33eeddb283ac725478900deac24151b019e496c476d59f72c38abb3",
 		"Incorrect daemon ID")
 
 	assert.NotEqual(t, dHeartbeat.ServiceHeartbeat, `{}`, "Service Heartbeat must not be empty.")
-	assert.Equal(t, dHeartbeat.ServiceHeartbeat, `{"serviceID":"SERVICE001", "status":"SERVING"}`,
+	assert.Equal(t, dHeartbeat.ServiceHeartbeat, `{"serviceID":"ExampleServiceId","status":"NOT_SERVING"}`,
 		"Unexpected service heartbeat")
 }
 
 func Test_GetHeartbeat(t *testing.T) {
-	serviceURL := "http://demo3208027.mockable.io/heartbeat"
+	serviceURL := "http://demo8325345.mockable.io/heartbeat"
 	serviceType := "http"
 	serviveID := "SERVICE001"
 
-	dHeartbeat,_ := GetHeartbeat(serviceURL, serviceType, serviveID)
+	dHeartbeat, _ := GetHeartbeat(serviceURL, serviceType, serviveID)
 	assert.NotNil(t, dHeartbeat, "heartbeat must not be nil")
 
 	assert.Equal(t, dHeartbeat.Status, Online.String(), "Invalid State")
@@ -79,8 +79,8 @@ func Test_GetHeartbeat(t *testing.T) {
 	assert.Equal(t, sHeartbeat.Status, grpc_health_v1.HealthCheckResponse_SERVING.String())
 
 	// check with some timeout URL
-	serviceURL = "http://demo3208027.mockable.io"
-	dHeartbeat,_ = GetHeartbeat(serviceURL, serviceType, serviveID)
+	serviceURL = "http://demo8325345.mockable.io"
+	dHeartbeat, _ = GetHeartbeat(serviceURL, serviceType, serviveID)
 	assert.NotNil(t, dHeartbeat, "heartbeat must not be nil")
 
 	assert.Equal(t, dHeartbeat.Status, Warning.String(), "Invalid State")
@@ -116,5 +116,5 @@ func TestSetNoHeartbeatURLState(t *testing.T) {
 func TestValidateHeartbeatConfig(t *testing.T) {
 	err := ValidateHeartbeatConfig()
 	assert.Nil(t, err)
-	assert.Equal(t, false, isNoHeartbeatURL)
+	assert.Equal(t, true, isNoHeartbeatURL)
 }

--- a/metrics/register_test.go
+++ b/metrics/register_test.go
@@ -21,12 +21,12 @@ func TestGetDaemonID(t *testing.T) {
 }
 
 func TestRegisterDaemon(t *testing.T) {
-	serviceURL := "https://demo3208027.mockable.io/register"
+	serviceURL := "https://demo8325345.mockable.io/register"
 
 	result := RegisterDaemon(serviceURL)
 	assert.Equal(t, true, result)
 
-	serviceURL = "https://demo3208027.mockable.io/registererror"
+	serviceURL = "https://demo8325345.mockable.io/registererror"
 	result = RegisterDaemon(serviceURL)
 	assert.Equal(t, false, result)
 }


### PR DESCRIPTION
corrected the Obsolete mockable URL used in Daemon metrics
Removed the usage of default service heartbeat as a mockable url
#340 