### PR TITLE
https://github.com/singnet/snet-daemon/issues/342

### DIFF
--- a/escrow/validation.go
+++ b/escrow/validation.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/singnet/snet-daemon/blockchain"
 )
+const (
+	PrefixInSignature = "__MPE_claim_message"
+)
 
 // ChannelPaymentValidator validates payment using payment channel state.
 type ChannelPaymentValidator struct {
@@ -68,6 +71,7 @@ func (validator *ChannelPaymentValidator) Validate(payment *Payment, channel *Pa
 
 func getSignerAddressFromPayment(payment *Payment) (signer *common.Address, err error) {
 	message := bytes.Join([][]byte{
+		[]byte(PrefixInSignature),
 		payment.MpeContractAddress.Bytes(),
 		bigIntToBytes(payment.ChannelID),
 		bigIntToBytes(payment.ChannelNonce),

--- a/escrow/validation_test.go
+++ b/escrow/validation_test.go
@@ -25,6 +25,7 @@ func ChannelPaymentValidatorMock() *ChannelPaymentValidator {
 
 func SignTestPayment(payment *Payment, privateKey *ecdsa.PrivateKey) {
 	message := bytes.Join([][]byte{
+		[]byte(PrefixInSignature),
 		payment.MpeContractAddress.Bytes(),
 		bigIntToBytes(payment.ChannelID),
 		bigIntToBytes(payment.ChannelNonce),
@@ -218,9 +219,8 @@ func (suite *ValidationTestSuite) TestGetPublicKeyFromPayment() {
 	}
 
 	address, err := getSignerAddressFromPayment(&payment)
-
 	assert.Nil(suite.T(), err, "Unexpected error: %v", err)
-	assert.Equal(suite.T(), blockchain.HexToAddress("0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef"), *address)
+	assert.Equal(suite.T(), blockchain.HexToAddress("0x77D524c6e0FD652aA9A9bFcAd1d92Fe0781767dF"), *address)
 }
 
 func (suite *ValidationTestSuite) TestGetPublicKeyFromPayment2() {
@@ -233,7 +233,6 @@ func (suite *ValidationTestSuite) TestGetPublicKeyFromPayment2() {
 	}
 
 	address, err := getSignerAddressFromPayment(&payment)
-
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), blockchain.HexToAddress("0x592E3C0f3B038A0D673F19a18a773F993d4b2610"), *address)
+	assert.Equal(suite.T(), blockchain.HexToAddress("0x6b1E951a2F9dE2480C613C1dCDDee4DD4CaE1e4e"), *address)
 }


### PR DESCRIPTION
Changes to the Signature per the latest MPE Contract
adding a prefix __MPE_claim_message

This is not to be merged till the latest contract is deployed 