### PR TITLE
Issues:372 , Support for Decimal value on config  rate_limit_minute

### DIFF
--- a/ratelimit/rateLimit.go
+++ b/ratelimit/rateLimit.go
@@ -4,6 +4,7 @@ import (
 	"github.com/singnet/snet-daemon/config"
 	"golang.org/x/time/rate"
 	"math"
+	"strconv"
 	"time"
 )
 
@@ -19,7 +20,13 @@ func NewRateLimiter() rate.Limiter {
 }
 
 func getLimit() rate.Limit {
-	ratePerMin := config.GetInt(config.RateLimitPerMinute)
+
+
+	ratePerMin, err := strconv.ParseFloat(config.GetString(config.RateLimitPerMinute), 32)
+	if err != nil {
+		return rate.Inf
+	}
+
 	//If the rate limit parameter Value is not defined we will assume it to be Infinity ( no Rate Limiting) ,
 	if ratePerMin == 0 {
 		return rate.Inf


### PR DESCRIPTION
The current code read rate_limit_per_minute as an integer always , this fix is to read a decimal value
You could now rate limit 1 request for every 2 minutes by configuring your rate_limit_minute as 0.5 ( assuming the average time for processing 1 request is 2 minutes)