### PR TITLE
Revert back to the old proto 

### DIFF
--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -30,10 +30,6 @@ func (service *BlockChainDisabledStateService) GetChannelState(context context.C
  return &ChannelStateReply{},nil
 }
 
-func (service *BlockChainDisabledStateService) GetAllChannelStates(context.Context, *AllChannelRequest) (*ChannelListReply, error) {
-	return &ChannelListReply{},nil
-}
-
 // verifies whether storage channel nonce is equal to blockchain nonce or not
 func (service *PaymentChannelStateService) StorageNonceMatchesWithBlockchainNonce(storageChannel *PaymentChannelData) (equal bool, err error) {
 	h := service.channelService
@@ -168,8 +164,4 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		CurrentSignedAmount: bigIntToBytes(channel.AuthorizedAmount),
 		CurrentSignature:    channel.Signature,
 	}, nil
-}
-//ToDO
-func (service *PaymentChannelStateService) GetAllChannelStates(context.Context, *AllChannelRequest) (*ChannelListReply, error) {
-	return &ChannelListReply{},nil
 }

--- a/escrow/state_service.proto
+++ b/escrow/state_service.proto
@@ -18,9 +18,6 @@ package escrow;
 service PaymentChannelStateService {
     // GetChannelState method returns a channel state by channel id.
     rpc GetChannelState(ChannelStateRequest) returns (ChannelStateReply) {}
-
-    //if signature field is present then response should be considered as invalid
-    rpc GetAllChannelStates(AllChannelRequest)  returns (ChannelListReply) {}
 }
 
 // ChanelStateRequest is a request for channel state.
@@ -34,17 +31,6 @@ message ChannelStateRequest {
 
     //current block number (signature will be valid only for short time around this block number)
     uint64 current_block = 3;
-}
-
-// ChanelStateRequest is a request for channel state.
-message AllChannelRequest {
-
-    // signature is a client signature of the message which contains
-    //Would comprise of the prefix = "__GetAllChannelStates_" + the current block number
-    bytes signature = 1;
-
-    //current block number (signature will be valid only for short time around this block number)
-    uint64 current_block = 2;
 }
 
 // ChannelStateReply message contains a latest channel state. current_nonce and
@@ -68,17 +54,4 @@ message ChannelStateReply {
 
     // last signature sent by client with nonce = current_nonce - 1
     bytes old_nonce_signature = 5;
-
-    //Indicates the current amount that is in the channel
-    bytes amount_deposited = 6;
-
-    //Expiry of the Channel
-    bytes expiry = 7;
  }
-
-
-
-message ChannelListReply {
-    repeated ChannelStateReply channels = 1;
-}
-


### PR DESCRIPTION
Adding a new method getAllchannelstate, seemed to bring in additional challenges in case  Daemon decides to become a bad actor 
#402 
example not return all the channels ( skip the ones with a lot of funds still available) .. and force the client to thus add more funds to existing channel even when not required
If client needs to validate the number of channels by going to the block chain , then the client could very well check details from the block chain himself ( source of truth) 