### PR TITLE
#278, remove obsolete code on checking old signatures

### DIFF
--- a/escrow/payment_handler.go
+++ b/escrow/payment_handler.go
@@ -115,7 +115,7 @@ func PublishChannelStats(payment handler.Payment) (err *handler.GrpcError) {
 		Nonce: paymentTransaction.Channel().Nonce,
 		GroupID:blockchain.BytesToBase64(paymentTransaction.Channel().GroupID[:]),
 	}
-	serviceURL := config.GetString(config.MeteringEndPoint)+"/contract-api/channel/"+channelStats.ChannelId.String()+"/consume"
+	serviceURL := config.GetString(config.MeteringEndPoint)+"/contract-api/channel/"+channelStats.ChannelId.String()+"/balance"
 
 	channelStats.OrganizationID = config.GetString(config.OrganizationId)
 	channelStats.ServiceID = config.GetString(config.ServiceId)

--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -96,11 +96,12 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		return nil, fmt.Errorf("channel is not found, channelId: %v", channelID)
 	}
 
-	if err := service.compareWithLatestBlockNumber(big.NewInt(int64(request.CurrentBlock))); err != nil {
-		return nil, err
-	}
 	if channel.Signer != *sender {
 		return nil, errors.New("only channel signer can get latest channel state")
+	}
+
+	if err := service.compareWithLatestBlockNumber(big.NewInt(int64(request.CurrentBlock))); err != nil {
+		return nil, err
 	}
 
 	// check if nonce matches with blockchain or not

--- a/escrow/state_service.go
+++ b/escrow/state_service.go
@@ -30,7 +30,6 @@ func (service *BlockChainDisabledStateService) GetChannelState(context context.C
 	return &ChannelStateReply{}, nil
 }
 
-
 // verifies whether storage channel nonce is equal to blockchain nonce or not
 func (service *PaymentChannelStateService) StorageNonceMatchesWithBlockchainNonce(storageChannel *PaymentChannelData) (equal bool, err error) {
 	h := service.channelService
@@ -97,33 +96,11 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		return nil, fmt.Errorf("channel is not found, channelId: %v", channelID)
 	}
 
-	//For backward compatibility
-	oldProto := false
-	blockNumberPassed := int64(request.CurrentBlock)
-
-
-
-	//TODO remove this fall back to older signature versions. this is temporary, only to enable backward compatibility
-	// with other components
-	if channel.Signer != *sender {
-		log.Infof("message does not follow the new signature standard. fall back to older signature standard")
-
-		sender, err = authutils.GetSignerAddressFromMessage(bigIntToBytes(channelID), signature)
-		if err != nil {
-			return nil, errors.New("incorrect signature")
-		}
-		if channel.Signer != *sender {
-			return nil, errors.New("only channel signer can get latest channel state")
-		}
-		if blockNumberPassed == 0 {
-			oldProto = true
-		}
+	if err := service.compareWithLatestBlockNumber(big.NewInt(int64(request.CurrentBlock))); err != nil {
+		return nil, err
 	}
-
-	if !oldProto {
-		if err := service.compareWithLatestBlockNumber(big.NewInt(int64(request.CurrentBlock))); err != nil {
-			return nil, err
-		}
+	if channel.Signer != *sender {
+		return nil, errors.New("only channel signer can get latest channel state")
 	}
 
 	// check if nonce matches with blockchain or not
@@ -167,4 +144,3 @@ func (service *PaymentChannelStateService) GetChannelState(context context.Conte
 		CurrentSignature:    channel.Signature,
 	}, nil
 }
-

--- a/escrow/state_service_test.go
+++ b/escrow/state_service_test.go
@@ -176,23 +176,6 @@ func TestGetChannelStateWhenNonceDiffers(t *testing.T) {
 	assert.Equal(t, previousChannelData.Signature, reply.OldNonceSignature)
 }
 
-func TestGetChannelStateChannelIdIsNotPaddedByZero(t *testing.T) {
-	channelId := big.NewInt(255)
-	stateServiceTest.channelServiceMock.Put(&PaymentChannelKey{ID: channelId}, stateServiceTest.defaultChannelData)
-	defer stateServiceTest.channelServiceMock.Clear()
-
-	reply, err := stateServiceTest.service.GetChannelState(
-		nil,
-		&ChannelStateRequest{
-			ChannelId: []byte{0xFF},
-			Signature: getSignature(bigIntToBytes(channelId), stateServiceTest.signerPrivateKey),
-		},
-	)
-
-	assert.Nil(t, err)
-	assert.Equal(t, stateServiceTest.defaultReply, reply)
-}
-
 func TestGetChannelStateChannelIdIncorrectSignature(t *testing.T) {
 	reply, err := stateServiceTest.service.GetChannelState(
 		nil,


### PR DESCRIPTION
All clients using Daemon ( ex SDK, DAPP and snet-cli) have updated to use the new proto , and hence removing the obsolete code
https://github.com/singnet/snet-daemon/issues/278