### PR TITLE
Remove warning banner

### DIFF
--- a/escrow/state_service.proto
+++ b/escrow/state_service.proto
@@ -1,9 +1,3 @@
-//
-// FIXME: All changes all this file should manually be copied to the `snet-cli`
-// repo until https://github.com/singnet/snet-daemon/issues/99 and
-// https://github.com/singnet/snet-cli/issues/88 are fixed.
-//
-
 syntax = "proto3";
 
 package escrow;


### PR DESCRIPTION
As singnet/snet-daemon#99 is closed, I think we can remove the banner.