### PR TITLE
Freecalls - Remove configs for free_call

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ see [etcd client configuration](./etcddb#etcd-client-configuration)
 * **payment_channel_storage_server** (optional) - 
 see [etcd server configuration](./etcddb#etcd-server-configuration)
 
-* **pvt_key_for_metering** (optional;only applies if `free_call_enabled` is set to true) 
-This is used for authentication between daemon and the metering service in the context of free calls.
+* **pvt_key_for_metering** (optional;only applies if `metering_enabled` is set to true) 
+This is used for authentication between daemon and the metering service in the context publishing stats , Even the latest Channel Status is published , this way the offline channel state balance can also be tracked.
 Daemon will send a signature signed by this private key , metering service will already have the public key corresponding
 to this Daemon ,metering service will ensure that the signer it receives matches the public key configured at its end.
-This is mandatory only when free calls are enabled.
+This is mandatory only when metering is enabled.
 
 
 * **rate_limit_per_minute** (optional; default: `Infinity`) - 

--- a/README.md
+++ b/README.md
@@ -217,10 +217,6 @@ The group helps determine the recipient address for payments.
 [service configuration
 metadata][service-configuration-metadata]. 
 
-* **free_call_end_point** (optional)     
-This parameter defines the end-point to publish usage of free-calls
-It becomes mandatory when free-call is enabled. Free call is enabled based on the service-metadata attribute 'free_calls' having a value greater than zero.
-
 * **log** (optional) - 
 see [logger configuration](./logger/README.md)
 

--- a/blockchain/serviceMetadata_test.go
+++ b/blockchain/serviceMetadata_test.go
@@ -14,7 +14,7 @@ var testJsonData = "{   \"version\": 1,   \"display_name\": \"Example1\",   \"en
 	"  \"mpe_address\": \"0x7E6366Fbe3bdfCE3C906667911FC5237Cc96BD08\",   \"groups\": [     {    \"free_calls\": 12,  \"free_call_signer_address\": \"0x7DF35C98f41F3Af0df1dc4c7F7D4C19a71Dd059F\",  \"endpoints\": [\"http://34.344.33.1:2379\",\"http://34.344.33.1:2389\"],       \"group_id\": \"88ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",\"group_name\": \"default_group\",       \"pricing\": [         {           \"price_model\": \"fixed_price\",           \"price_in_cogs\": 2         },          {         \"package_name\": \"example_service\",         \"price_model\": \"fixed_price_per_method\",         \"default\":true,         \"details\": [           {             \"service_name\": \"Calculator\",             \"method_pricing\": [               {                 \"method_name\": \"add\",                 \"price_in_cogs\": 2               },               {                 \"method_name\": \"sub\",                 \"price_in_cogs\": 1               },               {                 \"method_name\": \"div\",                 \"price_in_cogs\": 2               },               {                 \"method_name\": \"mul\",                 \"price_in_cogs\": 3               }             ]           },           {             \"service_name\": \"Calculator2\",             \"method_pricing\": [               {                 \"method_name\": \"add\",                 \"price_in_cogs\": 2               },               {                 \"method_name\": \"sub\",                 \"price_in_cogs\": 1               },               {                 \"method_name\": \"div\",                 \"price_in_cogs\": 3               },               {                 \"method_name\": \"mul\",                 \"price_in_cogs\": 2               }             ]           }         ]       }]     },     {       \"endpoints\": [\"http://97.344.33.1:2379\",\"http://67.344.33.1:2389\"],       \"group_id\": \"99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=\",       \"pricing\": [         {         \"package_name\": \"example_service\",         \"price_model\": \"fixed_price_per_method\",         \"details\": [           {             \"service_name\": \"Calculator\",             \"method_pricing\": [               {                 \"method_name\": \"add\",                 \"price_in_cogs\": 2               },               {                 \"method_name\": \"sub\",                 \"price_in_cogs\": 1               },               {                 \"method_name\": \"div\",                 \"price_in_cogs\": 2               },               {                 \"method_name\": \"mul\",                 \"price_in_cogs\": 3               }             ]           },           {             \"service_name\": \"Calculator2\",             \"method_pricing\": [               {                 \"method_name\": \"add\",                 \"price_in_cogs\": 2               },               {                 \"method_name\": \"sub\",                 \"price_in_cogs\": 1               },               {                 \"method_name\": \"div\",                 \"price_in_cogs\": 3               },               {                 \"method_name\": \"mul\",                 \"price_in_cogs\": 2               }             ]           }         ]       }]     }   ] } "
 
 func TestAllGetterMethods(t *testing.T) {
-	config.Vip().Set(config.FreeCallEndPoint, "http://demo8325345.mockable.io")
+
 	metaData, err := InitServiceMetaDataFromJson(testJsonData)
 	assert.Equal(t, err, nil)
 
@@ -47,11 +47,7 @@ func TestInitServiceMetaDataFromJson(t *testing.T) {
 	if err != nil {
 		assert.Equal(t, err.Error(), "MetaData does not have the default pricing set ")
 	}
-	config.Vip().Set(config.FreeCallEndPoint, "badurl")
-	_, err = InitServiceMetaDataFromJson(testJsonData)
-	if err != nil {
-		assert.Equal(t, err.Error(), "Please specify a valid end point for 'free_call_end_point' tracking usage of free calls ")
-	}
+
 }
 
 func TestReadServiceMetaDataFromLocalFile(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,6 @@ const (
 	DaemonGroupName                = "daemon_group_name"
 	DaemonTypeKey                  = "daemon_type"
 	DaemonEndPoint                 = "daemon_end_point"
-	FreeCallEndPoint               = "free_call_end_point"
 	ExecutablePathKey              = "executable_path"
 	IpfsEndPoint                   = "ipfs_end_point"
 	IpfsTimeout                    = "ipfs_timeout"

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -89,7 +89,7 @@ type ResponseStats struct {
 //If there is an error in the response received from the service, then send out a notification as well.
 func PublishResponseStats(commonStats *CommonStats, duration time.Duration, err error) bool {
 	response := createResponseStats(commonStats, duration, err)
-	return Publish(response, config.GetString(config.MeteringEndPoint) + "/usage/genericstats",commonStats)
+	return Publish(response, config.GetString(config.MeteringEndPoint) + "/metering/usage",commonStats)
 }
 
 func createResponseStats(commonStat *CommonStats, duration time.Duration, err error) *ResponseStats {

--- a/metrics/response_stats.go
+++ b/metrics/response_stats.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/grpc/status"
 	"math/big"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -90,9 +89,6 @@ type ResponseStats struct {
 //If there is an error in the response received from the service, then send out a notification as well.
 func PublishResponseStats(commonStats *CommonStats, duration time.Duration, err error) bool {
 	response := createResponseStats(commonStats, duration, err)
-	if  strings.Compare(commonStats.PaymentMode,"free-call") ==0  {
-		Publish(response, config.GetString(config.FreeCallEndPoint)+ "/usage/freecalls",commonStats)
-	}
 	return Publish(response, config.GetString(config.MeteringEndPoint) + "/usage/genericstats",commonStats)
 }
 

--- a/snetd/cmd/components.go
+++ b/snetd/cmd/components.go
@@ -278,6 +278,14 @@ func (components *Components) GrpcInterceptor() grpc.StreamServerInterceptor {
 	//Metering is now mandatory in Daemon
 	metrics.SetDaemonGrpId(components.OrganizationMetaData().GetGroupIdString())
 	if components.Blockchain().Enabled() && config.GetBool(config.MeteringEnabled) {
+			meteringUrl := config.GetString(config.MeteringEndPoint) + "/metering/verify"
+			if ok, err := components.verifyAuthenticationSetUpForFreeCall(meteringUrl,
+				components.OrganizationMetaData().GetGroupIdString()); !ok {
+				log.Error(err)
+				log.WithError(err).Panic("Metering authentication failed.Please verify the configuration" +
+					" as part of service publication process")
+			}
+
 		components.grpcInterceptor = grpc_middleware.ChainStreamServer(
 			handler.GrpcMeteringInterceptor(), handler.GrpcRateLimitInterceptor(components.ChannelBroadcast()),
 			components.GrpcPaymentValidationInterceptor())


### PR DESCRIPTION
#439 
Previously free-calls were used for metering , now Damon maintains a record/storage of all free call, this is to clean up the obsolete code in Daemon 