### PR TITLE
#481 : Add the channels Expiry as part of the response sent back 

### DIFF
--- a/escrow/control_service.go
+++ b/escrow/control_service.go
@@ -139,6 +139,7 @@ func (service *ProviderControlService) listChannels() (*PaymentsListReply, error
 			ChannelId:    bigIntToBytes(channel.ChannelID),
 			ChannelNonce: bigIntToBytes(channel.Nonce),
 			SignedAmount: bigIntToBytes(channel.AuthorizedAmount),
+			Expiry:       bigIntToBytes(channel.Expiration),
 		}
 		output = append(output, paymentReply)
 	}

--- a/escrow/control_service.go
+++ b/escrow/control_service.go
@@ -136,10 +136,10 @@ func (service *ProviderControlService) listChannels() (*PaymentsListReply, error
 			continue
 		}
 		paymentReply := &PaymentReply{
-			ChannelId:    bigIntToBytes(channel.ChannelID),
-			ChannelNonce: bigIntToBytes(channel.Nonce),
-			SignedAmount: bigIntToBytes(channel.AuthorizedAmount),
-			Expiry:       bigIntToBytes(channel.Expiration),
+			ChannelId:     bigIntToBytes(channel.ChannelID),
+			ChannelNonce:  bigIntToBytes(channel.Nonce),
+			SignedAmount:  bigIntToBytes(channel.AuthorizedAmount),
+			ChannelExpiry: bigIntToBytes(channel.Expiration),
 		}
 		output = append(output, paymentReply)
 	}

--- a/escrow/control_service.proto
+++ b/escrow/control_service.proto
@@ -49,6 +49,9 @@ message PaymentReply {
 
     //this filed must be OMITED in GetListUnclaimed request
     bytes signature = 4;
+
+    //indicative of the Channel Expiry in block number
+    bytes expiry = 5;
 }
 
 message PaymentsListReply {

--- a/escrow/control_service.proto
+++ b/escrow/control_service.proto
@@ -51,7 +51,7 @@ message PaymentReply {
     bytes signature = 4;
 
     //indicative of the Channel Expiry in block number
-    bytes expiry = 5;
+    bytes channel_expiry = 5;
 }
 
 message PaymentsListReply {


### PR DESCRIPTION
pass the Channels' expiry on the response  This information is valuable for the user to determine which claims need Urgent attention and are gonna expire soon / have expired
#481 