### PR TITLE
#487 :set passthrough_enabled = true by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,14 @@ metadata][service-configuration-metadata].
 Id of the service to search for [service configuration
 metadata][service-configuration-metadata].
 
-* **passthrough_enabled** (optional; default: `false`) - 
+* **passthrough_enabled** (optional; default: `true`) - 
 when passthrough is disabled, daemon echoes requests back as responses; `false`
 reserved mostly for testing purposes.
 
 * **passthrough_endpoint** (required if `service_type` != `executable`) - 
 endpoint to which requests should be proxied for handling by service.
+This config is mandatory when `passthrough_enabled` is set to true.
+and needs to be a valid url
 
 * **executable_path** (required if `service_type` == `executable`) - 
 path to executable to expose as a service.

--- a/config/config.go
+++ b/config/config.go
@@ -310,7 +310,7 @@ func ValidateEndpoints(daemonEndpoint string, passthroughEndpoint string) error 
 
 	passthroughURL, err := url.Parse(passthroughEndpoint)
 	if err != nil || passthroughURL.Host == "" {
-		return errors.New("passthrough_endpoint must be a valid URL")
+		return errors.New("passthrough_endpoint is the endpoint of your AI service in the daemon config and needs to be a valid url.")
 	}
 	daemonHost, daemonPort, err := net.SplitHostPort(daemonEndpoint)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,7 @@ const (
 	"max_message_size_in_mb" : 4,
 	"metering_enabled": false,
 	"organization_id": "ExampleOrganizationId", 
-	"passthrough_enabled": false,
+	"passthrough_enabled": true,
 	"service_id": "ExampleServiceId", 
 	"private_key": "",
 	"ssl_cert": "",
@@ -307,9 +307,10 @@ func ValidateEmail(email string) bool {
 }
 
 func ValidateEndpoints(daemonEndpoint string, passthroughEndpoint string) error {
+
 	passthroughURL, err := url.Parse(passthroughEndpoint)
-	if err != nil {
-		return errors.New("passthrough endpoint must be a valid URL")
+	if err != nil || passthroughURL.Host == "" {
+		return errors.New("passthrough_endpoint must be a valid URL")
 	}
 	daemonHost, daemonPort, err := net.SplitHostPort(daemonEndpoint)
 	if err != nil {
@@ -332,6 +333,7 @@ var userAddress []common.Address
 
 func IsAllowedUser(address *common.Address) bool {
 	for _, user := range userAddress {
+		log.Println("userAddressFromConfig:" + user.Hex() + "<>" + address.Hex())
 		if user == *address {
 			return true
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,7 +116,7 @@ func TestValidateEndpoints(t *testing.T) {
 	err = ValidateEndpoints("1.2.3.4:8080", "http://127.0.0.1:8080")
 	assert.Equal(t, nil, err)
 	err = ValidateEndpoints("1.2.3.4:8080", "")
-	assert.Equal(t, "passthrough_endpoint must be a valid URL", err.Error())
+	assert.Equal(t, "passthrough_endpoint is the endpoint of your AI service in the daemon config and needs to be a valid url.", err.Error())
 }
 
 func TestAllowedUserChecks(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,6 +115,8 @@ func TestValidateEndpoints(t *testing.T) {
 	assert.Equal(t, nil, err)
 	err = ValidateEndpoints("1.2.3.4:8080", "http://127.0.0.1:8080")
 	assert.Equal(t, nil, err)
+	err = ValidateEndpoints("1.2.3.4:8080", "")
+	assert.Equal(t, "passthrough_endpoint must be a valid URL", err.Error())
 }
 
 func TestAllowedUserChecks(t *testing.T) {


### PR DESCRIPTION
by default enforce this behavoir

set passthrough_enabled = true

the user also needs to specify a valid URL for the config passthrough_endpoint

user has the choice to set the value to false explicitly