### PR TITLE
fix: fix slice init length

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -446,7 +446,7 @@ func SetAllowedUsers() (err error) {
 	if len(users) == 0 {
 		return fmt.Errorf("a valid Address needs to be specified for the config %v to ensure that, only these users can make calls", AllowedUserAddresses)
 	}
-	userAddress = make([]common.Address, len(users))
+	userAddress = make([]common.Address, 0, len(users))
 	for _, user := range users {
 		if !common.IsHexAddress(user) {
 			err = fmt.Errorf("%v is not a valid hex address", user)


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of `len(users)` rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW