### PR TITLE
minor text cleanup

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -133,7 +133,7 @@ Sample Payload for response stats
   will have to post all the captured metrics.
 
 * **monitoring_enabled** (optional. ```true|false, default value is true```) - Enables or disables daemon monitoring. By
-  default it is set to true. When enabled DAemon captures the request and resposne metrics and post to the end point.
+  default it is set to true. When enabled DAemon captures the request and response metrics and post to the end point.
 
 ##### Service endpoint
 

--- a/storage/atomic_storage.go
+++ b/storage/atomic_storage.go
@@ -281,7 +281,7 @@ func (storage *TypedAtomicStorageImpl) GetAll() (array any, err error) {
 	return values.Interface(), nil
 }
 
-// Put implementor TypedAtomicStorage.Put
+// Put implementer TypedAtomicStorage.Put
 func (storage *TypedAtomicStorageImpl) Put(key any, value any) (err error) {
 	keyString, err := storage.keySerializer(key)
 	if err != nil {


### PR DESCRIPTION
improved wording and consistency in code:
`resposne` - `response`
`implementor` - `implementer`