### PR TITLE
fix(metrics): unconfigured heartbeat reports Warning not Online

### DIFF
--- a/metrics/heartbeat.go
+++ b/metrics/heartbeat.go
@@ -162,17 +162,22 @@ func GetHeartbeat(serviceEndpoint string, serviceHeartbeatURL string, heartbeatT
 		serviceHeartbeatBytes, err = callHTTPServiceHeartbeat(serviceHeartbeatURL)
 		heartbeat.ServiceHeartbeat = string(serviceHeartbeatBytes)
 		zap.L().Debug("Get heartbeat", zap.String("serviceHeartbeatURL", serviceHeartbeatURL), zap.String("serviceHeartbeatBytes", string(serviceHeartbeatBytes)), zap.Error(err))
-	case "none":
-		fallthrough
 	case "tcp":
-		fallthrough
-	case "":
-		// trying to ping the service with serviceEndpoint
+		// Explicit TCP heartbeat: dial the service endpoint.
 		err = tcpPingService(serviceEndpoint)
 		zap.L().Debug("Get heartbeat [tcpPingService]", zap.String("serviceEndpoint", serviceEndpoint), zap.Error(err))
+	case "none", "":
+		// No heartbeat configured. Do not claim Online from a TCP accept —
+		// a wedged process can still accept connections. Report Warning so
+		// consumers can tell "verified" from "unchecked".
+		heartbeat.Status = Warning.String()
+		zap.L().Debug("heartbeat not configured; not claiming Online via TCP accept",
+			zap.String("heartbeatType", heartbeatType),
+			zap.String("serviceEndpoint", serviceEndpoint))
 	}
 
-	if err == nil {
+	// "none"/"" already set Warning above; only promote Online when a real check succeeded.
+	if err == nil && heartbeatType != "none" && heartbeatType != "" {
 		curResp.Status = "SERVING"
 		heartbeat.Status = Online.String()
 	}

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -136,7 +136,7 @@ func (suite *HeartBeatTestSuite) TestHeartbeatHandler() {
 	assert.True(suite.T(), dHeartbeat.TrainingMetadataData.TrainingInProto)
 	assert.NotNil(suite.T(), dHeartbeat, "heartbeat must not be nil")
 
-	assert.Equal(suite.T(), Offline.String(), dHeartbeat.Status, "Invalid State")
+	assert.Equal(suite.T(), Warning.String(), dHeartbeat.Status, "unconfigured heartbeat must report Warning, not a false Online")
 	//assert.NotEqual(suite.T(), Offline.String(), dHeartbeat.Status, "Invalid State")
 
 	assert.Equal(suite.T(), "20e986a77adb1ab0900dce6f554128496aa26be1e212d682f37898bae226fcfc", dHeartbeat.DaemonID,

--- a/metrics/heartbeat_unconfigured_test.go
+++ b/metrics/heartbeat_unconfigured_test.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/singnet/snet-daemon/v6/training"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func acceptOnly(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return "http://" + ln.Addr().String()
+}
+
+func servingHTTP(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"SERVING"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func noTraining() (*training.TrainingMetadata, error) { return nil, nil }
+func noBlock() (*big.Int, error)                      { return big.NewInt(0), nil }
+
+// Unconfigured heartbeat types must not report Online merely because a TCP
+// listener accepts a connection (issue #694).
+func TestGetHeartbeatUnconfiguredDoesNotClaimOnline(t *testing.T) {
+	dead := acceptOnly(t)
+	for _, hb := range []string{"", "none"} {
+		t.Run("type_"+hbOrEmpty(hb), func(t *testing.T) {
+			h, err := GetHeartbeat(dead, "", hb, "svc", noTraining, map[string]string{}, noBlock)
+			require.NoError(t, err)
+			assert.Equal(t, Warning.String(), h.Status,
+				"unconfigured heartbeat must not look like a verified Online")
+			assert.Contains(t, h.ServiceHeartbeat, `"status":"NOT_SERVING"`)
+		})
+	}
+}
+
+func hbOrEmpty(s string) string {
+	if s == "" {
+		return "empty"
+	}
+	return s
+}
+
+// Explicit tcp type still uses the TCP dial path.
+func TestGetHeartbeatTCPStillPings(t *testing.T) {
+	dead := acceptOnly(t)
+	h, err := GetHeartbeat(dead, "", "tcp", "svc", noTraining, map[string]string{}, noBlock)
+	require.NoError(t, err)
+	assert.Equal(t, Online.String(), h.Status)
+}
+
+func TestGetHeartbeatHTTPOKRemainsOnline(t *testing.T) {
+	url := servingHTTP(t)
+	h, err := GetHeartbeat(url, url+"/heartbeat", "http", "svc", noTraining, map[string]string{}, noBlock)
+	require.NoError(t, err)
+	assert.Equal(t, Online.String(), h.Status)
+}


### PR DESCRIPTION
## Description
Unconfigured heartbeat types (`""` / `"none"`) no longer claim `Online` from a TCP accept. They report `Warning` with `NOT_SERVING` so consumers can tell an unchecked service from a verified one. Explicit `"tcp"` still uses `tcpPingService`.

Fixes #694.

## Changes
- `GetHeartbeat`: route `"none"`/`""` away from `tcpPingService`; keep `"tcp"` on the dial path
- Tests for accept-only listeners (unconfigured → Warning, tcp → Online) plus HTTP path still Online
- Update `TestHeartbeatHandler` expectation to match the unconfigured Warning status

## Interface changes
Daemon heartbeat JSON status for unconfigured types is now `"Warning"` instead of a false `"Online"`. gRPC health `Check` accordingly returns non-SERVING for those configs (same as any non-Online status today).

## Test plan
- [x] `go test ./metrics/ -count=1`